### PR TITLE
feat: CU 행사 상품 전체 조회하는 기능 구현

### DIFF
--- a/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
+++ b/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
@@ -10,7 +10,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -25,10 +24,9 @@ import java.util.stream.Collectors;
 public class CuEventBatchService extends EventBatchService {
 
     private static final String CU_URL = "https://cu.bgfretail.com/event/plusAjax.do?";
-    private static final String DOCUMENT_SELECT_TAG = "a.prod_item";
-    private static final int TIMEOUT = 30000;
+    private static final String DOC_SELECT_TAG = "a.prod_item";
+    private static final int TIMEOUT = 5000;
 
-    @Autowired
     public CuEventBatchService(EventProductRepository eventProductRepository) {
         super(eventProductRepository);
     }
@@ -39,8 +37,9 @@ public class CuEventBatchService extends EventBatchService {
         try {
             return getProducts();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            log.error("CU 행사 상품 조회하는 데 실패했습니다.", e);
         }
+        return null; // 이후에 에러 처리 관련 수정 - getAllProducts() 호출하는 쪽에 throw
     }
 
     @Override
@@ -73,7 +72,7 @@ public class CuEventBatchService extends EventBatchService {
         while (true) {
             String pagedCuEventUrl = getSevenEventUrlByPageIndex(pageIndex);
             Document doc = Jsoup.connect(pagedCuEventUrl).timeout(TIMEOUT).get();
-            Elements elements = doc.select(DOCUMENT_SELECT_TAG);
+            Elements elements = doc.select(DOC_SELECT_TAG);
 
             if (elements.isEmpty()) {
                 break;

--- a/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
+++ b/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class CuEventBatchService extends EventBatchService {
 
-    private static final String CU_URL= "https://cu.bgfretail.com/event/plusAjax.do?";
+    private static final String CU_URL = "https://cu.bgfretail.com/event/plusAjax.do?";
 
     @Autowired
     public CuEventBatchService(EventProductRepository eventProductRepository) {
@@ -32,14 +32,12 @@ public class CuEventBatchService extends EventBatchService {
 
     @Override
     protected List<BaseEventProduct> getAllProducts() {
-        List<BaseEventProduct> results = new ArrayList<>();
 
         try {
-            results.addAll(getProducts());
+            return getProducts();
         } catch (Exception e) {
-            log.error("해당 페이지에 접근하지 못합니다. {}", e.getMessage());
+            throw new RuntimeException(e);
         }
-        return results;
     }
 
     @Override
@@ -70,7 +68,7 @@ public class CuEventBatchService extends EventBatchService {
 
         int pageIndex = 1;
         while (true) {
-            String CU_EVENT_URL_TMP = CU_URL+ "pageIndex=" + pageIndex;
+            String CU_EVENT_URL_TMP = CU_URL + "pageIndex=" + pageIndex;
             Document doc = Jsoup.connect(CU_EVENT_URL_TMP).timeout(0).get();
             Elements elements = doc.select("a.prod_item");
 
@@ -93,7 +91,7 @@ public class CuEventBatchService extends EventBatchService {
         String price = element.select("div.price > strong").first().text();
         String eventTypeTag = element.select("div.badge").first().text();
         EventType eventType = EventType.getEventTypeWithValue(eventTypeTag);
-        
+
         return BaseEventProduct.builder()
                 .name(name)
                 .image(image)

--- a/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
+++ b/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
@@ -1,17 +1,30 @@
 package com.pyonsnalcolor.batch.service.cu;
 
 import com.pyonsnalcolor.batch.model.BaseEventProduct;
+import com.pyonsnalcolor.batch.model.EventType;
+import com.pyonsnalcolor.batch.model.StoreType;
 import com.pyonsnalcolor.batch.repository.EventProductRepository;
 import com.pyonsnalcolor.batch.service.EventBatchService;
 import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service("CuEvent")
 @Slf4j
 public class CuEventBatchService extends EventBatchService {
+
+    private static final String CU_URL= "https://cu.bgfretail.com/event/plusAjax.do?";
+
     @Autowired
     public CuEventBatchService(EventProductRepository eventProductRepository) {
         super(eventProductRepository);
@@ -19,11 +32,14 @@ public class CuEventBatchService extends EventBatchService {
 
     @Override
     protected List<BaseEventProduct> getAllProducts() {
-        /**
-         * TODO : 여기 크롤링한 모든 상품들을 반환하는 기능을 구현해주시면 됩니다.
-         */
-        System.out.println("get expired Cu event products");
-        return null;
+        List<BaseEventProduct> results = new ArrayList<>();
+
+        try {
+            results.addAll(getProducts());
+        } catch (Exception e) {
+            log.error("해당 페이지에 접근하지 못합니다. {}", e.getMessage());
+        }
+        return results;
     }
 
     @Override
@@ -47,5 +63,44 @@ public class CuEventBatchService extends EventBatchService {
     @Override
     protected void sendAlarms(List<BaseEventProduct> CuProducts) {
         System.out.println("send event Cu products alarms");
+    }
+
+    private List<BaseEventProduct> getProducts() throws IOException {
+        List<BaseEventProduct> products = new ArrayList<>();
+
+        int pageIndex = 1;
+        while (true) {
+            String CU_EVENT_URL_TMP = CU_URL+ "pageIndex=" + pageIndex;
+            Document doc = Jsoup.connect(CU_EVENT_URL_TMP).timeout(0).get();
+            Elements elements = doc.select("a.prod_item");
+
+            if (elements.isEmpty()) {
+                break;
+            }
+
+            List<BaseEventProduct> tmp = elements.stream()
+                    .map(this::convertToBaseEventProduct)
+                    .collect(Collectors.toList());
+            products.addAll(tmp);
+            pageIndex++;
+        }
+        return products;
+    }
+
+    private BaseEventProduct convertToBaseEventProduct(Element element) {
+        String name = element.select("div.name").first().text();
+        String image = element.select("img.prod_img").first().attr("src");
+        String price = element.select("div.price > strong").first().text();
+        String eventTypeTag = element.select("div.badge").first().text();
+        EventType eventType = EventType.getEventTypeWithValue(eventTypeTag);
+        
+        return BaseEventProduct.builder()
+                .name(name)
+                .image(image)
+                .price(price)
+                .eventType(eventType)
+                .storeType(StoreType.CU.getName())
+                .updatedTime(LocalDateTime.now())
+                .build();
     }
 }


### PR DESCRIPTION
### 구현 사항
- CU 행사 상품 전체 조회하는 기능 구현

### 참고 사항
- [CU 행사 상품 홈페이지 주소](https://cu.bgfretail.com/event/plus.do?category=event&depth2=1&sf=N)
- CU는 행사상품이 1+1, 2+1만 있습니다.