### PR TITLE
feat: Kakao OAuth + 자체 JWT 로그인 기능 구현

### DIFF
--- a/pyonsnalcolor-member/pom.xml
+++ b/pyonsnalcolor-member/pom.xml
@@ -18,21 +18,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-batch</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
@@ -43,13 +34,51 @@
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-
-
+		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-core -->
 		<dependency>
-			<groupId>org.springframework.batch</groupId>
-			<artifactId>spring-batch-test</artifactId>
-			<scope>test</scope>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-core</artifactId>
+			<version>5.5.0</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework.security.oauth/spring-security-oauth2 -->
+		<dependency>
+			<groupId>org.springframework.security.oauth</groupId>
+			<artifactId>spring-security-oauth2</artifactId>
+			<version>2.5.2.RELEASE</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-config -->
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-config</artifactId>
+			<version>5.5.0</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.10.1</version>
+		</dependency>
+
+
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -66,18 +95,15 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
 				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<compilerVersion>${java.version}</compilerVersion>
 				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/config/SecurityConfig.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.pyonsnalcolor.member.config;
+
+import com.pyonsnalcolor.member.handler.CustomAccessDeniedHandler;
+import com.pyonsnalcolor.member.handler.CustomAuthenticationEntryPoint;
+import com.pyonsnalcolor.member.jwt.JwtAuthenticationFilter;
+import com.pyonsnalcolor.member.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Autowired
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring()
+                .antMatchers( "/resources/**");
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .httpBasic().disable()
+                .csrf().disable()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+                .authorizeRequests()
+                .antMatchers("/auth/**").permitAll()
+                .antMatchers("/member/**").hasRole("USER")
+                .anyRequest().authenticated()
+            .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint()) // 인증X
+                .accessDeniedHandler(new CustomAccessDeniedHandler())           // 인증O, 인가X
+            .and()
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new CustomUserDetailsService();
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/controller/AuthController.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.pyonsnalcolor.member.controller;
+
+import com.pyonsnalcolor.member.dto.AuthorizationRequestDto;
+import com.pyonsnalcolor.member.dto.TokenDto;
+import com.pyonsnalcolor.member.entity.enumtype.LoginType;
+import com.pyonsnalcolor.member.oauth.kakao.KakaoOauthService;
+import com.pyonsnalcolor.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final MemberService memberService;
+    private final KakaoOauthService kakaoOauthService;
+
+    @PostMapping("/kakao")
+    public ResponseEntity<TokenDto> authorizationWithKakao(
+            @RequestBody AuthorizationRequestDto authorizationRequestDto
+    ) {
+        String email = kakaoOauthService.getKakaoEmail(authorizationRequestDto);
+        TokenDto tokenDto = memberService.join(LoginType.KAKAO, email);
+        return new ResponseEntity(tokenDto, HttpStatus.OK);
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/controller/AuthController.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/controller/AuthController.java
@@ -28,4 +28,10 @@ public class AuthController {
         TokenDto tokenDto = memberService.join(LoginType.KAKAO, email);
         return new ResponseEntity(tokenDto, HttpStatus.OK);
     }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissueAccessToken(@RequestBody TokenDto tokenDto) {
+        TokenDto newTokenDto = memberService.reissueAccessToken(tokenDto);
+        return new ResponseEntity(newTokenDto, HttpStatus.OK);
+    }
 }

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/dto/AuthorizationRequestDto.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/dto/AuthorizationRequestDto.java
@@ -1,0 +1,9 @@
+package com.pyonsnalcolor.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthorizationRequestDto {
+
+    private String authorizationCode;
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/dto/TokenDto.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/dto/TokenDto.java
@@ -1,0 +1,12 @@
+package com.pyonsnalcolor.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+public class TokenDto {
+
+    private String accessToken;
+
+    private String refreshToken;
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/entity/CustomUserDetails.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/entity/CustomUserDetails.java
@@ -1,0 +1,52 @@
+package com.pyonsnalcolor.member.entity;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(member.getRole().toString()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getOauthId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/entity/Member.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/entity/Member.java
@@ -1,0 +1,32 @@
+package com.pyonsnalcolor.member.entity;
+
+import com.pyonsnalcolor.member.entity.enumtype.LoginType;
+import com.pyonsnalcolor.member.entity.enumtype.Role;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Builder
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+public class Member {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String oauthId; // {Oauth 타입 + 사용자 정보}
+
+    private String email;
+
+    private String refreshToken;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType;
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/entity/enumtype/LoginType.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/entity/enumtype/LoginType.java
@@ -1,0 +1,15 @@
+package com.pyonsnalcolor.member.entity.enumtype;
+
+public enum LoginType {
+    APPLE("apple-"), KAKAO("kakao-");
+
+    private String header;
+
+    LoginType(String header) {
+        this.header = header;
+    }
+
+    public String addLoginTypeHeaderWithEmail(String email) {
+        return this.header + email;
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/entity/enumtype/Role.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/entity/enumtype/Role.java
@@ -1,0 +1,5 @@
+package com.pyonsnalcolor.member.entity.enumtype;
+
+public enum Role {
+    ROLE_USER, ROLE_GUEST, ROLE_ADMIN;
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/handler/CustomAccessDeniedHandler.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,24 @@
+package com.pyonsnalcolor.member.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.sendError(HttpStatus.FORBIDDEN.value());
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/handler/CustomAuthenticationEntryPoint.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.pyonsnalcolor.member.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.sendError(HttpStatus.UNAUTHORIZED.value());
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/jwt/JwtAuthenticationFilter.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.pyonsnalcolor.member.jwt;
+
+import com.pyonsnalcolor.member.service.CustomUserDetailsService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@PropertySource("classpath:application.yml")
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Value("${jwt.bearer.header}")
+    private String bearerHeader;
+
+    @Value("${jwt.access-token.header}")
+    private String accessTokenHeader;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = resolveBearerToken(request, accessTokenHeader);
+
+        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+            saveAuthentication(accessToken);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void saveAuthentication(String accessToken) {
+        Authentication authentication = createAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    public Authentication createAuthentication(String token) {
+        String oauthId = (String) jwtTokenProvider.getClaims(token).get("oauthId");
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(oauthId);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private String resolveBearerToken(HttpServletRequest request, String header) {
+        String bearerToken = request.getHeader(header);
+        if (bearerToken != null && bearerToken.startsWith(bearerHeader)) {
+            return bearerToken.substring(bearerHeader.length());
+        }
+        return null;
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/jwt/JwtTokenProvider.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/jwt/JwtTokenProvider.java
@@ -1,0 +1,113 @@
+package com.pyonsnalcolor.member.jwt;
+
+import com.pyonsnalcolor.member.dto.TokenDto;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+@PropertySource("classpath:application.yml")
+public class JwtTokenProvider {
+
+    @Value("${jwt.issuer}")
+    private String jwtIssuer;
+
+    @Value("${jwt.bearer.header}")
+    private String bearerHeader;
+
+    @Value("${jwt.secret}")
+    private String jwtSecretKey;
+
+    @Value("${jwt.access-token.validity}")
+    private long accessTokenValidity;
+
+    @Value("${jwt.refresh-token.validity}")
+    private long refreshTokenValidity;
+
+    private SecretKey secretKey;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String jwtSecretKey,
+                            @Value("${jwt.access-token.validity}") long accessTokenValidity,
+                            @Value("${jwt.refresh-token.validity}") long refreshTokenValidity) {
+        this.accessTokenValidity = accessTokenValidity;
+        this.refreshTokenValidity = refreshTokenValidity;
+        this.secretKey = Keys.hmacShaKeyFor(jwtSecretKey.getBytes());
+    }
+
+    public TokenDto createAccessAndRefreshTokenDto(String oauthId) {
+        String accessToken = createAccessToken(oauthId);
+        String refreshToken = createRefreshToken(oauthId);
+
+        return TokenDto.builder()
+                .accessToken(createBearerHeader(accessToken))
+                .refreshToken(createBearerHeader(refreshToken))
+                .build();
+    }
+
+    public String createAccessToken(String oauthId){
+        return createJwtTokenWithValidity(oauthId, accessTokenValidity);
+    }
+
+    public String createRefreshToken(String oauthId){
+        return createJwtTokenWithValidity(oauthId, refreshTokenValidity);
+    }
+
+    private String createJwtTokenWithValidity(String oauthId, long tokenValidity){
+        Date now = new Date();
+        Date expirationAt = new Date(now.getTime() + tokenValidity);
+
+        Claims claims = Jwts.claims()
+                .setIssuer(jwtIssuer)
+                .setIssuedAt(now)
+                .setExpiration(expirationAt);
+        claims.put("oauthId", oauthId);
+
+        return Jwts.builder()
+                .setIssuer(jwtIssuer)
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expirationAt)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (MalformedJwtException e) {
+            throw new MalformedJwtException("토큰 형식이 잘못되어 있습니다.");
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("만료된 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException("지원하지 않는 형식의 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Claim이 유효하지 않은 토큰입니다.");
+        }
+    }
+
+    public Claims getClaims(String token) {
+
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtIssuer)
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public String getOauthId(String token) {
+        return (String) getClaims(token).get("oauthId");
+    }
+
+    private String createBearerHeader (String token) {
+        return bearerHeader + token;
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/kakao/KakaoOauthService.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/kakao/KakaoOauthService.java
@@ -1,0 +1,74 @@
+package com.pyonsnalcolor.member.oauth.kakao;
+
+import com.pyonsnalcolor.member.dto.AuthorizationRequestDto;
+import com.pyonsnalcolor.member.oauth.kakao.dto.KakaoOauthTokenDto;
+import com.pyonsnalcolor.member.oauth.kakao.dto.KakaoUserInfoDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@PropertySource("classpath:application-oauth.yml")
+public class KakaoOauthService {
+
+    @Value("${spring.security.oauth2.kakao.grant-type}")
+    private String grantType;
+
+    @Value("${spring.security.oauth2.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${spring.security.oauth2.kakao.access-token-uri}")
+    private String accessTokenUri;
+
+    @Value("${spring.security.oauth2.kakao.request-uri}")
+    private String requestUri;
+
+    public String getKakaoEmail(AuthorizationRequestDto authorizationRequestDto) {
+        String accessToken = getAccessToken(authorizationRequestDto);
+        return getKakaoUserInfo(accessToken).getEmail();
+    }
+
+    private String getAccessToken (AuthorizationRequestDto authorizationRequestDto) {
+        KakaoOauthTokenDto kakaoOauthTokenDto = getKakaoOauthToken(authorizationRequestDto);
+        return kakaoOauthTokenDto.getAccessToken();
+    }
+
+    private KakaoOauthTokenDto getKakaoOauthToken (AuthorizationRequestDto authorizationRequestDto) {
+        String authorizeCode = authorizationRequestDto.getAuthorizationCode();
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", grantType);
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", authorizeCode);
+
+        HttpEntity<?> request = new HttpEntity<>(body, headers);
+        return restTemplate.postForObject(accessTokenUri, request, KakaoOauthTokenDto.class);
+    }
+
+    private KakaoUserInfoDto getKakaoUserInfo (String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        return restTemplate.postForObject(requestUri, request, KakaoUserInfoDto.class);
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/kakao/dto/KakaoOauthTokenDto.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/kakao/dto/KakaoOauthTokenDto.java
@@ -1,0 +1,22 @@
+package com.pyonsnalcolor.member.oauth.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoOauthTokenDto {
+
+    private String accessToken;
+
+    private String tokenType;
+
+    private String refreshToken;
+
+    private String expiresIn;
+
+    private String refreshTokenExpiresIn;
+
+    private String scope;
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/kakao/dto/KakaoUserInfoDto.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/kakao/dto/KakaoUserInfoDto.java
@@ -1,0 +1,20 @@
+package com.pyonsnalcolor.member.oauth.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoUserInfoDto {
+
+    private KakaoAccount kakaoAccount;
+
+    static class KakaoAccount {
+        private String email;
+    }
+
+    public String getEmail() {
+        return kakaoAccount.email;
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/repository/MemberRepository.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.pyonsnalcolor.member.repository;
+
+import com.pyonsnalcolor.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByOauthId(String oauthId);
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/repository/MemberRepository.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.pyonsnalcolor.member.repository;
 
 import com.pyonsnalcolor.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +12,8 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByOauthId(String oauthId);
+
+    @Query("select m.refreshToken from Member m where m.oauthId= :oauthId")
+    Optional<String> findRefreshTokenByOauthId(@Param("oauthId") String oauthId);
+
 }

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/service/CustomUserDetailsService.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/service/CustomUserDetailsService.java
@@ -1,0 +1,40 @@
+package com.pyonsnalcolor.member.service;
+
+import com.pyonsnalcolor.member.entity.Member;
+import com.pyonsnalcolor.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Component
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findByOauthId(username)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 사용자가 없습니다."));
+        return createUserDetails(member);
+    }
+
+    private UserDetails createUserDetails(Member member) {
+        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority(member.getRole().toString()));
+
+        return new User(
+                member.getOauthId(),
+                "",
+                grantedAuthorities);
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/service/MemberService.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/service/MemberService.java
@@ -1,0 +1,50 @@
+package com.pyonsnalcolor.member.service;
+
+import com.pyonsnalcolor.member.dto.TokenDto;
+import com.pyonsnalcolor.member.entity.Member;
+import com.pyonsnalcolor.member.entity.enumtype.LoginType;
+import com.pyonsnalcolor.member.entity.enumtype.Role;
+import com.pyonsnalcolor.member.jwt.JwtTokenProvider;
+import com.pyonsnalcolor.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@PropertySource("classpath:application.yml")
+public class MemberService {
+
+    @Value("${jwt.access-token.validity}")
+    private long accessTokenValidity;
+
+    @Value("${jwt.bearer.header}")
+    private String bearerHeader;
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public TokenDto join(LoginType loginType, String email) {
+        String oauthId = loginType.addLoginTypeHeaderWithEmail(email);
+        TokenDto tokenDto = jwtTokenProvider.createAccessAndRefreshTokenDto(oauthId);
+        String refreshToken = tokenDto.getRefreshToken();
+
+        boolean isMemberEmpty = memberRepository.findByOauthId(oauthId).isEmpty();
+        if (isMemberEmpty) {
+            Member member = Member.builder()
+                    .email(email)
+                    .refreshToken(refreshToken)
+                    .oauthId(oauthId)
+                    .loginType(loginType)
+                    .role(Role.ROLE_USER)
+                    .build();
+            memberRepository.save(member);
+        }
+        return tokenDto;
+    }
+}

--- a/pyonsnalcolor-member/src/main/resources/application-oauth.yml
+++ b/pyonsnalcolor-member/src/main/resources/application-oauth.yml
@@ -1,0 +1,9 @@
+spring:
+  security:
+    oauth2:
+      kakao:
+        access-token-uri: ${KAKAO_ACCESS_TOKEN_URI}
+        grant-type: ${KAKAO_GRANT_TYPE}
+        client-id: ${KAKAO_CLIENT_ID}
+        redirect-uri: ${KAKAO_REDIRECT_URI}
+        request-uri: ${KAKAO_REQUEST_URI}

--- a/pyonsnalcolor-member/src/main/resources/application.yml
+++ b/pyonsnalcolor-member/src/main/resources/application.yml
@@ -1,0 +1,40 @@
+spring:
+  config:
+    import:
+      - optional:classpath:/application-oauth.yml
+  server:
+    address: localhost
+    port: 8080
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create
+      show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+      encoding: UTF-8
+jwt:
+  issuer: ${JWT_ISSUER}
+  secret: ${JWT_SECRET}
+  bearer:
+    header: ${JWT_BEARER_HEADER}
+  access-token:
+    header: ${JWT_ACCESS_TOKEN_HEADER}
+    validity: ${JWT_ACCESS_TOKEN_VALIDITY}
+  refresh-token:
+    header: ${JWT_REFRESH_TOKEN_HEADER}
+    validity: ${JWT_REFRESH_TOKEN_VALIDITY}


### PR DESCRIPTION
## 구현 사항
- Kakao OAuth에서 Access Token 발급받고 사용자 정보 요청(REST API)
- 사용자 정보(이메일)로 자체 JWT 로그인 구현
- Access 토큰 재발급 기능 구현
- MySQL 로컬 연결 - yml 파일

## 참고 사항
#### ☑ **Kakao OAuth(REST API) + 자체 JWT 로그인 기능 흐름 설명**
1.   클라에서 받은 `인가 코드`(로그인 성공 시 받음)로
2.   백에서 Kakao에 `Access Token` 요청함
3.   Kakao에게 받은 `Access Token`으로 다시 Kakao에 `사용자 정보(이메일)` 요청
4.   이 `사용자 정보(이메일)`로 자체 JWT 생성

#### ☑ Access/Refresh Token 관련 설명
- 만료기간 : Access Token은 하루, Refresh Token은 일단 무제한 (클라분들과 상의했습니다)
- Refresh Token은 일단 RDB에 함께 저장
- Refresh Token은 일단 무제한이라 재발급 기능X

#### ☑ 이후 Apple도 같은 흐름으로 JWT 생성
- 애플/카카오에 등록된 이메일이 같을 수 있어서
- apple-userA@gmail.com
- kakao-userA@gmail.com
- 이렇게 이메일 앞에 OAuth 타입을 적은 `oauthId`를 사용자 구분 키로 사용함
- JWT의 Claims에도 해당 값 설정

+) 인증/인가 실패 시의 response는 후에 http 스펙 클라분들과 정하고 추가 예정입니다
++) 근데 PR 단위가 좀 큰가요..?