### PR TITLE
feat: Apple OAuth + 자체 JWT 로그인 기능 구현

### DIFF
--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/config/SecurityConfig.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.pyonsnalcolor.member.handler.CustomAuthenticationEntryPoint;
 import com.pyonsnalcolor.member.jwt.JwtAuthenticationFilter;
 import com.pyonsnalcolor.member.service.CustomUserDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,6 +17,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.client.RestTemplate;
 
 @EnableWebSecurity
 @Configuration
@@ -60,5 +62,10 @@ public class SecurityConfig {
     @Bean
     public UserDetailsService userDetailsService() {
         return new CustomUserDetailsService();
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder.build();
     }
 }

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/controller/AuthController.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.pyonsnalcolor.member.controller;
 import com.pyonsnalcolor.member.dto.LoginRequestDto;
 import com.pyonsnalcolor.member.dto.TokenDto;
 import com.pyonsnalcolor.member.entity.enumtype.LoginType;
+import com.pyonsnalcolor.member.oauth.apple.AppleOauthService;
 import com.pyonsnalcolor.member.oauth.kakao.KakaoOauthService;
 import com.pyonsnalcolor.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class AuthController {
 
     private final MemberService memberService;
     private final KakaoOauthService kakaoOauthService;
+    private final AppleOauthService appleOauthService;
 
     @PostMapping("/kakao")
     public ResponseEntity<TokenDto> authorizationWithKakao(
@@ -26,6 +28,15 @@ public class AuthController {
     ) {
         String email = kakaoOauthService.getEmail(loginRequestDto);
         TokenDto tokenDto = memberService.join(LoginType.KAKAO, email);
+        return new ResponseEntity(tokenDto, HttpStatus.OK);
+    }
+
+    @PostMapping("/apple")
+    public ResponseEntity<TokenDto> authorizationWithApple(
+            @RequestBody LoginRequestDto loginRequestDto
+    ) {
+        String email = appleOauthService.getEmail(loginRequestDto);
+        TokenDto tokenDto = memberService.join(LoginType.APPLE, email);
         return new ResponseEntity(tokenDto, HttpStatus.OK);
     }
 

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/apple/AppleOauthService.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/apple/AppleOauthService.java
@@ -1,0 +1,113 @@
+package com.pyonsnalcolor.member.oauth.apple;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pyonsnalcolor.member.dto.LoginRequestDto;
+import com.pyonsnalcolor.member.oauth.apple.dto.ApplePublicKeyDto;
+import com.pyonsnalcolor.member.oauth.apple.dto.ApplePublicKeysDto;
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Slf4j
+@Service
+@PropertySource("classpath:application-oauth.yml")
+public class AppleOauthService {
+
+    private static final String EMAIL = "email";
+    private static final String ALG = "alg";
+    private static final String KID = "kid";
+
+    @Value("${spring.security.oauth2.apple.key-uri}")
+    private String keyUri;
+
+    @Value("${spring.security.oauth2.apple.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.apple.issuer}")
+    private String issuer;
+
+    public String getEmail(LoginRequestDto loginRequestDto) {
+        String identityToken = loginRequestDto.getToken();
+        PublicKey publicKeyForParseIdentityToken = createPublicKeyForParseIdentityToken(identityToken);
+
+        Claims claims = parseAndValidateClaims(identityToken, publicKeyForParseIdentityToken);
+        return claims.get(EMAIL, String.class);
+    }
+
+    private PublicKey createPublicKeyForParseIdentityToken(String identityToken) {
+        ApplePublicKeyDto selectedApplePublicKey = selectApplePublicKeyMatchesIdentityToken(identityToken);
+
+        byte[] nBytes = Base64.getUrlDecoder().decode(selectedApplePublicKey.getN());
+        byte[] eBytes = Base64.getUrlDecoder().decode(selectedApplePublicKey.getE());
+
+        BigInteger n = new BigInteger(1, nBytes);
+        BigInteger e = new BigInteger(1, eBytes);
+
+        try {
+            RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+            KeyFactory keyFactory = KeyFactory.getInstance(selectedApplePublicKey.getKty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (InvalidKeySpecException | NoSuchAlgorithmException exception) {
+            throw new JwtException("Identity token을 파싱할 공개키를 생성할 수 없습니다.");
+        }
+    }
+
+    private ApplePublicKeyDto selectApplePublicKeyMatchesIdentityToken(String identityToken) {
+        Map<String, String> headerMap = parseHeaderOfIdentityToken(identityToken);
+        String alg = headerMap.get(ALG);
+        String kid = headerMap.get(KID);
+
+        ApplePublicKeysDto keys = getApplePublicKeysFromApple();
+        return keys.getApplePublicKeyMatchesAlgAndKid(alg, kid);
+    }
+
+    private Map<String, String> parseHeaderOfIdentityToken(String identityToken) {
+        try {
+            String header = identityToken.substring(0, identityToken.indexOf("."));
+            Map<String, String> parsedHeader = new ObjectMapper().readValue(
+                    new String(Base64.getDecoder().decode(header), "UTF-8"), Map.class);
+            return parsedHeader;
+        } catch (JsonProcessingException | UnsupportedEncodingException e) {
+            throw new JwtException("Identity token의 형식이 유효하지 않습니다.");
+        }
+    }
+
+    private ApplePublicKeysDto getApplePublicKeysFromApple() {
+        RestTemplate restTemplate = new RestTemplate();
+        return restTemplate.getForObject(keyUri, ApplePublicKeysDto.class);
+    }
+
+    private Claims parseAndValidateClaims(String identityToken, PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .requireAudience(clientId)
+                    .requireIssuer(issuer)
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(identityToken)
+                    .getBody();
+        } catch (MalformedJwtException e) {
+            throw new MalformedJwtException("Identity token의 형식이 잘못되었습니다.");
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("Identity token이 만료되었습니다.");
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException("Identity token이 지원하지 않는 형식입니다.");
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Identity token의 Claim이 유효하지 않습니다.");
+        }
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/apple/dto/ApplePublicKeyDto.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/apple/dto/ApplePublicKeyDto.java
@@ -1,0 +1,19 @@
+package com.pyonsnalcolor.member.oauth.apple.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ApplePublicKeyDto {
+
+    private String alg;
+
+    private String kid;
+
+    private String kty;
+
+    private String use;
+
+    private String n;
+
+    private String e;
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/apple/dto/ApplePublicKeysDto.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/apple/dto/ApplePublicKeysDto.java
@@ -1,0 +1,20 @@
+package com.pyonsnalcolor.member.oauth.apple.dto;
+
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class ApplePublicKeysDto {
+
+    private List<ApplePublicKeyDto> keys;
+
+    public ApplePublicKeyDto getApplePublicKeyMatchesAlgAndKid(String alg, String kid) {
+        return keys
+                .stream()
+                .filter(k -> k.getAlg().equals(alg) && k.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException("사용자의 identity token에 맞는 Apple 공개키가 존재하지 않습니다.")
+                );
+    }
+}

--- a/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/kakao/KakaoOauthService.java
+++ b/pyonsnalcolor-member/src/main/java/com/pyonsnalcolor/member/oauth/kakao/KakaoOauthService.java
@@ -3,6 +3,7 @@ package com.pyonsnalcolor.member.oauth.kakao;
 import com.pyonsnalcolor.member.dto.LoginRequestDto;
 import com.pyonsnalcolor.member.oauth.kakao.dto.KakaoUserInfoDto;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpEntity;
@@ -26,14 +27,15 @@ public class KakaoOauthService {
     @Value("${spring.security.oauth2.kakao.request-uri}")
     private String requestUri;
 
+    @Autowired
+    private RestTemplate restTemplate;
+
     public String getEmail(LoginRequestDto loginRequestDto) {
         String accessToken = loginRequestDto.getToken();
         return getKakaoUserInfo(accessToken).getEmail();
     }
 
     private KakaoUserInfoDto getKakaoUserInfo (String accessToken) {
-        RestTemplate restTemplate = new RestTemplate();
-
         HttpHeaders headers = new HttpHeaders();
         headers.add(accessTokenHeader, bearerHeader + accessToken);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);

--- a/pyonsnalcolor-member/src/main/resources/application-oauth.yml
+++ b/pyonsnalcolor-member/src/main/resources/application-oauth.yml
@@ -3,3 +3,7 @@ spring:
     oauth2:
       kakao:
         request-uri: ${KAKAO_REQUEST_URI}
+      apple:
+        key-uri: ${APPLE_KEY_URI}
+        issuer: ${APPLE_ISSUER}
+        client-id: ${APPLE_CLIENT_ID}


### PR DESCRIPTION
### 구현 사항
- Apple OAuth 로그인 후, 이메일 추출하여 자체 JWT 로그인 구현

### 참고 사항

#### ☑ **Apple OAuth(REST API) + 자체 JWT 로그인 기능 흐름 설명**
1. (클라에서 Apple 로그인 성공 후 받은) Identity Token에서
2. Apple에서 받은 공개키를 활용하여 이메일 추출하고 
3. 해당 이메일로 자체 JWT 로그인 구현

#### 구체적인 내부 동작 흐름
  - #13 

+) 저번 리뷰 내용이랑 Kakao/Apple 겹치는 부분은 새 브랜치에서 코드 수정하겠습니다~
