### PR TITLE
feat: 세븐일레븐 행사 상품 전체 조회하는 기능 구현

### DIFF
--- a/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
+++ b/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
@@ -1,57 +1,27 @@
 package com.pyonsnalcolor.batch.service.seven;
 
 import com.pyonsnalcolor.batch.model.BaseEventProduct;
-import com.pyonsnalcolor.batch.model.EventType;
-import com.pyonsnalcolor.batch.model.StoreType;
 import com.pyonsnalcolor.batch.repository.EventProductRepository;
 import com.pyonsnalcolor.batch.service.EventBatchService;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static com.pyonsnalcolor.batch.model.UUIDGenerator.generateId;
 
 @Service("SevenEvent")
 @Slf4j
 public class SevenEventBatchService extends EventBatchService {
 
     private static final String SEVEN_URL = "https://www.7-eleven.co.kr/product/listMoreAjax.asp?intPageSize=10";
-    private static final String IMG_PREFIX = "https://www.7-eleven.co.kr";
     private static final int TIMEOUT = 5000;
-
-    private enum SevenEventTab {
-        ONE_TO_ONE(1, 0),
-        TWO_TO_ONE(2, 0),
-        GIFT(3, 1),
-        DISCOUNT(4, 0);
-
-        private int tab;
-        private int startPageIndex;
-
-        SevenEventTab(int tab, int startPageIndex) {
-            this.tab = tab;
-            this.startPageIndex = startPageIndex;
-        }
-
-        private String getDocumentTag() {
-            if (this == GIFT) {
-                return "div.pic_product";
-            }
-            return "div.pic_product div.pic_product";
-        }
-    }
 
     public SevenEventBatchService(EventProductRepository eventProductRepository) {
         super(eventProductRepository);
@@ -78,11 +48,11 @@ public class SevenEventBatchService extends EventBatchService {
         return null;
     }
 
-    private List<BaseEventProduct> getProductsByTab(SevenEventTab sevenEventTab) throws IOException {
+    public List<BaseEventProduct> getProductsByTab(SevenEventTab sevenEventTab) throws IOException {
         List<BaseEventProduct> products = new ArrayList<>();
 
-        int pageIndex = sevenEventTab.startPageIndex;
-        int tab = sevenEventTab.tab;
+        int pageIndex = sevenEventTab.getStartPageIndex();
+        int tab = sevenEventTab.getTab();
         while (true) {
             String sevenEventUrl = getSevenEventUrlByPageIndexAndTab(pageIndex, tab);
             Document doc = Jsoup.connect(sevenEventUrl).timeout(TIMEOUT).get();
@@ -92,30 +62,11 @@ public class SevenEventBatchService extends EventBatchService {
                 break;
             }
 
-            List<BaseEventProduct> tmp = elements.stream()
-                    .map (p -> convertToBaseEventProduct(p, sevenEventTab))
-                    .collect(Collectors.toList());
-            products.addAll(tmp);
+            List<BaseEventProduct> pagedProducts = sevenEventTab.getPagedProducts(elements);
+            products.addAll(pagedProducts);
             pageIndex++;
         }
         return products;
-    }
-
-    private BaseEventProduct convertToBaseEventProduct(Element element, SevenEventTab sevenEventTab) {
-        String name = element.select("div.name").first().text();
-        String image = IMG_PREFIX + element.select("img").first().attr("src");
-        String price = element.select("div.price").text();
-        EventType eventType = EventType.getEventTypeWithValue(sevenEventTab.name());
-
-        return BaseEventProduct.builder()
-                .name(name)
-                .id(generateId())
-                .image(image)
-                .price(price)
-                .updatedTime(LocalDateTime.now())
-                .eventType(eventType)
-                .storeType(StoreType.SEVEN_ELEVEN)
-                .build();
     }
 
     private String getSevenEventUrlByPageIndexAndTab(int pageIndex, int tab) {

--- a/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
+++ b/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
@@ -1,28 +1,129 @@
 package com.pyonsnalcolor.batch.service.seven;
 
 import com.pyonsnalcolor.batch.model.BaseEventProduct;
+import com.pyonsnalcolor.batch.model.EventType;
+import com.pyonsnalcolor.batch.model.StoreType;
 import com.pyonsnalcolor.batch.repository.EventProductRepository;
 import com.pyonsnalcolor.batch.service.EventBatchService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.pyonsnalcolor.batch.model.UUIDGenerator.generateId;
 
 @Service("SevenEvent")
 @Slf4j
 public class SevenEventBatchService extends EventBatchService {
-    @Autowired
+
+    private static final String SEVEN_URL = "https://www.7-eleven.co.kr/product/listMoreAjax.asp?intPageSize=10";
+    private static final String IMG_PREFIX = "https://www.7-eleven.co.kr";
+    private static final int TIMEOUT = 5000;
+
+    private enum SevenEventTab {
+        ONE_TO_ONE(1, 0),
+        TWO_TO_ONE(2, 0),
+        GIFT(3, 1),
+        DISCOUNT(4, 0);
+
+        private int tab;
+        private int startPageIndex;
+
+        SevenEventTab(int tab, int startPageIndex) {
+            this.tab = tab;
+            this.startPageIndex = startPageIndex;
+        }
+
+        private String getDocumentTag() {
+            if (this == GIFT) {
+                return "div.pic_product";
+            }
+            return "div.pic_product div.pic_product";
+        }
+    }
+
     public SevenEventBatchService(EventProductRepository eventProductRepository) {
         super(eventProductRepository);
     }
 
     @Override
     protected List<BaseEventProduct> getAllProducts() {
-        /**
-         * TODO : 여기 크롤링한 모든 상품들을 반환하는 기능을 구현해주시면 됩니다.
-         */
-        System.out.println("get expired Seven event products");
+        List<BaseEventProduct> products = new ArrayList<>();
+
+        Arrays.stream(SevenEventTab.values())
+                .sequential()
+                .map(this::getProductsAllTab)
+                .filter(Objects::nonNull)
+                .forEach(products::addAll);
+        return products;
+    }
+
+    private List<BaseEventProduct> getProductsAllTab(SevenEventTab sevenEventTab) {
+        try {
+            return getProductsByTab(sevenEventTab);
+        } catch (IOException ioException) {
+            log.error("세븐일레븐 이벤트 {}탭의 상품 조회하는 데 실패했습니다.", sevenEventTab, ioException);
+        }
         return null;
+    }
+
+    private List<BaseEventProduct> getProductsByTab(SevenEventTab sevenEventTab) throws IOException {
+        List<BaseEventProduct> products = new ArrayList<>();
+
+        int pageIndex = sevenEventTab.startPageIndex;
+        int tab = sevenEventTab.tab;
+        while (true) {
+            String sevenEventUrl = getSevenEventUrlByPageIndexAndTab(pageIndex, tab);
+            Document doc = Jsoup.connect(sevenEventUrl).timeout(TIMEOUT).get();
+            Elements elements = doc.select(sevenEventTab.getDocumentTag());
+
+            if (elements.isEmpty()) {
+                break;
+            }
+
+            List<BaseEventProduct> tmp = elements.stream()
+                    .map (p -> convertToBaseEventProduct(p, sevenEventTab))
+                    .collect(Collectors.toList());
+            products.addAll(tmp);
+            pageIndex++;
+        }
+        return products;
+    }
+
+    private BaseEventProduct convertToBaseEventProduct(Element element, SevenEventTab sevenEventTab) {
+        String name = element.select("div.name").first().text();
+        String image = IMG_PREFIX + element.select("img").first().attr("src");
+        String price = element.select("div.price").text();
+        EventType eventType = EventType.getEventTypeWithValue(sevenEventTab.name());
+
+        return BaseEventProduct.builder()
+                .name(name)
+                .id(generateId())
+                .image(image)
+                .price(price)
+                .updatedTime(LocalDateTime.now())
+                .eventType(eventType)
+                .storeType(StoreType.SEVEN_ELEVEN)
+                .build();
+    }
+
+    private String getSevenEventUrlByPageIndexAndTab(int pageIndex, int tab) {
+        return UriComponentsBuilder
+                .fromUriString(SEVEN_URL)
+                .queryParam("intCurrPage", pageIndex)
+                .queryParam("pTab", tab)
+                .build()
+                .toString();
     }
 }

--- a/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
+++ b/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
@@ -1,0 +1,91 @@
+package com.pyonsnalcolor.batch.service.seven;
+
+import com.pyonsnalcolor.batch.model.BaseEventProduct;
+import com.pyonsnalcolor.batch.model.EventType;
+import com.pyonsnalcolor.batch.model.StoreType;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static com.pyonsnalcolor.batch.model.UUIDGenerator.generateId;
+
+@Slf4j
+public enum SevenEventTab {
+
+    ONE_TO_ONE(1, 0),
+    TWO_TO_ONE(2, 0),
+    GIFT(3, 1),
+    DISCOUNT(4, 0);
+
+    @Getter
+    private int tab;
+    @Getter
+    private int startPageIndex;
+
+    private static final String IMG_PREFIX = "https://www.7-eleven.co.kr";
+
+    SevenEventTab(int tab, int startPageIndex) {
+        this.tab = tab;
+        this.startPageIndex = startPageIndex;
+    }
+
+    public String getDocumentTag() {
+        if (this == GIFT) {
+            return "div.pic_product";
+        }
+        return "div.pic_product div.pic_product";
+    }
+
+    public List<BaseEventProduct> getPagedProducts(Elements elements) {
+        if (this == GIFT) {
+            getPagedProductsByGift(elements);
+        }
+        return elements.stream()
+                .map (p -> convertToBaseEventProduct(p, null))
+                .collect(Collectors.toList());
+    }
+
+    private BaseEventProduct convertToBaseEventProduct(Element element, Element giftElement) {
+        String name = element.select("div.name").first().text();
+        String image = IMG_PREFIX + element.select("img").first().attr("src");
+        String price = element.select("div.price").text();
+        EventType eventType = EventType.getEventTypeWithValue(this.name());
+        String giftImage = null;
+        if (giftElement != null) {
+            giftImage = IMG_PREFIX + giftElement.select("img").first().attr("src");
+        }
+
+        return BaseEventProduct.builder()
+                .name(name)
+                .id(generateId())
+                .image(image)
+                .price(price)
+                .giftImage(giftImage)
+                .updatedTime(LocalDateTime.now())
+                .eventType(eventType)
+                .storeType(StoreType.SEVEN_ELEVEN)
+                .build();
+    }
+
+    private List<BaseEventProduct> getPagedProductsByGift(Elements elements) {
+        AtomicInteger counter = new AtomicInteger();
+        List<BaseEventProduct> pagedProducts = new ArrayList<>();
+
+        elements.stream()
+                .collect(Collectors.groupingBy(it -> counter.getAndIncrement() / 2))
+                .forEach((classifier, products) -> {
+                    Element originElement = products.get(0);
+                    Element giftElement = products.get(1);
+                    BaseEventProduct baseEventProduct = convertToBaseEventProduct(originElement, giftElement);
+                    pagedProducts.add(baseEventProduct);
+                });
+        return pagedProducts;
+    }
+}

--- a/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
+++ b/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
@@ -45,7 +45,7 @@ public enum SevenEventTab {
 
     public List<BaseEventProduct> getPagedProducts(Elements elements) {
         if (this == GIFT) {
-            getPagedProductsByGift(elements);
+            return getPagedProductsByGift(elements);
         }
         return elements.stream()
                 .map (p -> convertToBaseEventProductWithGift(p, null))

--- a/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
+++ b/pyonsnalcolor-batch/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
@@ -48,11 +48,11 @@ public enum SevenEventTab {
             getPagedProductsByGift(elements);
         }
         return elements.stream()
-                .map (p -> convertToBaseEventProduct(p, null))
+                .map (p -> convertToBaseEventProductWithGift(p, null))
                 .collect(Collectors.toList());
     }
 
-    private BaseEventProduct convertToBaseEventProduct(Element element, Element giftElement) {
+    private BaseEventProduct convertToBaseEventProductWithGift(Element element, Element giftElement) {
         String name = element.select("div.name").first().text();
         String image = IMG_PREFIX + element.select("img").first().attr("src");
         String price = element.select("div.price").text();
@@ -83,7 +83,7 @@ public enum SevenEventTab {
                 .forEach((classifier, products) -> {
                     Element originElement = products.get(0);
                     Element giftElement = products.get(1);
-                    BaseEventProduct baseEventProduct = convertToBaseEventProduct(originElement, giftElement);
+                    BaseEventProduct baseEventProduct = convertToBaseEventProductWithGift(originElement, giftElement);
                     pagedProducts.add(baseEventProduct);
                 });
         return pagedProducts;


### PR DESCRIPTION
### 구현 사항

- 세븐일레븐 행사 상품 전체 조회하는 기능 구현

### 참고 사항

- 행사 탭 중 **증정 상품**일때만 
  시작 페이지 넘버/태그 깊이가 다르고 처리가 까다로워서 
  enum으로 따로 빼주었습니다~

![image](https://github.com/YAPP-Github/22nd-iOS-Team-2-BE/assets/77563814/289f28a3-53da-4160-8f5b-730df0b8a918)
