### PR TITLE
feat: FCM 환경 설정, 테스트용 구현

### DIFF
--- a/pyonsnalcolor-alarm/pom.xml
+++ b/pyonsnalcolor-alarm/pom.xml
@@ -23,6 +23,11 @@
 			<artifactId>pyonsnalcolor-domain</artifactId>
 			<version>1.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.firebase</groupId>
+			<artifactId>firebase-admin</artifactId>
+			<version>9.2.0</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>
@@ -40,18 +45,15 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
 				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<compilerVersion>${java.version}</compilerVersion>
 				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/pyonsnalcolor-alarm/src/main/java/com/pyonsnalcolor/alarm/dto/DeviceTokenRequestDto.java
+++ b/pyonsnalcolor-alarm/src/main/java/com/pyonsnalcolor/alarm/dto/DeviceTokenRequestDto.java
@@ -1,0 +1,15 @@
+package com.pyonsnalcolor.alarm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeviceTokenRequestDto {
+
+    private String deviceToken;
+}

--- a/pyonsnalcolor-alarm/src/main/java/com/pyonsnalcolor/alarm/dto/FcmMessageType.java
+++ b/pyonsnalcolor-alarm/src/main/java/com/pyonsnalcolor/alarm/dto/FcmMessageType.java
@@ -1,0 +1,44 @@
+package com.pyonsnalcolor.alarm.dto;
+
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.Getter;
+
+@Getter
+public enum FcmMessageType {
+
+    PB("새로운 차별화 상품이 업데이트 되었어요! \uD83D\uDC95", ""),
+    EVENT("새로운 행사가 시작되었어요! \uD83C\uDF81", ""),
+    KEYWORD_PB("가 업데이트되었어요\uD83D\uDC95", ""),
+    KEYWORD_EVENT("의 행사가 시작되었어요\uD83C\uDF81", "");
+
+    private static final String DEEPLINK = "deeplink";
+    private static final String PYONSNAL_COLOR = "편스널 컬러";
+    private static final String IMAGE = ""; // 후에 이미지 추가
+
+    private final String bodyMessage;
+    private final String deeplink;
+
+    FcmMessageType(String bodyMessage, String deeplink) {
+        this.bodyMessage = bodyMessage;
+        this.deeplink = deeplink;
+    }
+
+    public Message createMessage(String deviceToken) {
+        Notification notification = createNotification(deviceToken);
+
+        return Message.builder()
+                .setToken(deviceToken)
+                .setNotification(notification)
+                .putData(DEEPLINK, deeplink) // 이후에 상품id 추가
+                .build();
+    }
+
+    private Notification createNotification(String deviceToken) {
+        return Notification.builder()
+                .setTitle(PYONSNAL_COLOR)
+                .setBody(PB.getBodyMessage())
+                // .setImage() // 이후에 아이콘 이미지 추가
+                .build();
+    }
+}

--- a/pyonsnalcolor-alarm/src/main/java/com/pyonsnalcolor/alarm/fcm/FcmController.java
+++ b/pyonsnalcolor-alarm/src/main/java/com/pyonsnalcolor/alarm/fcm/FcmController.java
@@ -1,0 +1,24 @@
+package com.pyonsnalcolor.alarm.fcm;
+
+import com.pyonsnalcolor.alarm.dto.DeviceTokenRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.concurrent.ExecutionException;
+
+@Controller
+@RequiredArgsConstructor
+public class FcmController {
+
+    private final FcmPushService fcmPushService;
+
+    // ios 테스트용
+    @GetMapping("/fcm/test")
+    public ResponseEntity fcmTest(DeviceTokenRequestDto deviceTokenRequestDto) throws ExecutionException, InterruptedException {
+        fcmPushService.pbFcmTest(deviceTokenRequestDto);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/pyonsnalcolor-alarm/src/main/java/com/pyonsnalcolor/alarm/fcm/FcmPushService.java
+++ b/pyonsnalcolor-alarm/src/main/java/com/pyonsnalcolor/alarm/fcm/FcmPushService.java
@@ -1,0 +1,60 @@
+package com.pyonsnalcolor.alarm.fcm;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.pyonsnalcolor.alarm.dto.DeviceTokenRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+import static com.pyonsnalcolor.alarm.dto.FcmMessageType.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmPushService {
+
+    @Value("${fcm.key}")
+    private String FCM_KEY;
+
+    @Value("${fcm.scope}")
+    private String FIREBASE_SCOPE;
+
+    private FirebaseMessaging firebaseMessaging;
+
+    @PostConstruct
+    public void fcmInit() throws IOException {
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(FCM_KEY).getInputStream())
+                .createScoped((Arrays.asList(FIREBASE_SCOPE)));
+
+        FirebaseOptions firebaseOptions = FirebaseOptions.builder()
+                .setCredentials(googleCredentials)
+                .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions);
+            this.firebaseMessaging = FirebaseMessaging.getInstance(app);
+            log.info("Firebase 어플리케이션을 초기화 했습니다.");
+        }
+    }
+
+    // 테스트용 PB 상품 알림
+    public void pbFcmTest(DeviceTokenRequestDto deviceTokenRequestDto) throws ExecutionException, InterruptedException {
+        String deviceToken = deviceTokenRequestDto.getDeviceToken();
+        log.info("알림 테스트 시작, 사용자 토큰 : {}", deviceToken);
+
+        Message message = PB.createMessage(deviceToken);
+        this.firebaseMessaging.sendAsync(message).get();
+    }
+}

--- a/pyonsnalcolor-alarm/src/main/resources/application.yml
+++ b/pyonsnalcolor-alarm/src/main/resources/application.yml
@@ -13,3 +13,6 @@ spring:
     hibernate:
       ddl-auto: create
       show-sql: true
+fcm:
+  key: fcm-key.json
+  scope: https://www.googleapis.com/auth/firebase.messaging


### PR DESCRIPTION
### 구현 사항
- FCM 환경 설정
- ios 테스트용 api 구현

### 참고 사항
- `fcm-key.json` 추가 필요
- 테스트용 api: 사용자 토큰을 req으로 받으면, ios에 푸시 알림
- 이후에는 controller 필요X, 스케쥴링 사용해서 일정시간마다 알림 발송
- #27  