### PR TITLE
fix: LocalDateTime 직렬화 오류 해결

### DIFF
--- a/pyonsnalcolor-api/build.gradle
+++ b/pyonsnalcolor-api/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
     // FCM
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 description = 'pyonsnalcolor-api'

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
@@ -1,5 +1,8 @@
 package com.pyonsnalcolor.product.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,5 +26,7 @@ public class BaseProduct {
     @Indexed
     private String name;
     private String price;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime updatedTime;
 }


### PR DESCRIPTION
### 구현 사항
- 상품 조회시 상품 엔티티(BaseProduct)의 LocalDateTime 역직렬화 오류 해결
- response 타입 지정("yyyy-MM-dd")

### 참고 사항
- Jackson Mapper 라이브러리 버전 낮을 경우(LocalDateTime가 나온 Java 8 이전) 에러 발생
=> jackson-datatype-jsr310 추가
=> @JsonDeserialize 사용