### PR TITLE
chore: Swagger 헤더 입력 방식 변경

### DIFF
--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/SwaggerConfig.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/SwaggerConfig.java
@@ -13,28 +13,25 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
-
         SecurityScheme bearerAuth = new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")
-                .name("bearerAuth");
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
 
-        SecurityScheme bearerRef = new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")
-                .name("bearerRef");
+        SecurityScheme bearerRefresh = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("Refresh");
 
-        SecurityRequirement addSecurityItem = new SecurityRequirement();
-        addSecurityItem.addList("Authorization");
-        addSecurityItem.addList("Refresh");
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Authorization")
+                .addList("Refresh");
 
         return new OpenAPI()
                 .components(new Components()
                         .addSecuritySchemes("Authorization", bearerAuth)
-                        .addSecuritySchemes("Refresh", bearerRef))
-                .addSecurityItem(addSecurityItem)
+                        .addSecuritySchemes("Refresh", bearerRefresh))
+                .addSecurityItem(securityRequirement)
                 .info(apiInfo());
     }
 


### PR DESCRIPTION
### 구현 사항
- Swagger 헤더 입력 방식 변경
  - `SecurityScheme.Type.HTTP` - >`SecurityScheme.Type.APIKEY`
- `SecurityScheme.Type.HTTP` 방식에서는 
  - Authorization 헤더(Access 토큰), Refresh 헤더(Refresh 토큰) 중 하나만 입력 헤더로 설정되는 오류 발생
  -> 로그아웃 시, Access이 무효화되어도 헤더에 Refresh 토큰이 입력되어 계속 로그인 가능

### 참고 사항
- https://swagger.io/docs/specification/authentication/api-keys/

![image](https://github.com/YAPP-Github/pyonsnalcolor-server/assets/77563814/6c1f9435-0205-4702-a1e6-d2bc09e299ec)
