### PR TITLE
Feature/batch CU 상세 정보 조회 기능 추가

### DIFF
--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/AuthController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "AuthController", description = "사용자 인증/인가용 api")
+@Tag(name = "사용자 인증/인가용 api")
 @Slf4j
 @RestController
 @RequiredArgsConstructor

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/MemberController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/MemberController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-@Tag(name = "MemberController", description = "(인증 제외)사용자 관련 api")
+@Tag(name = "(인증 제외)사용자 관련 api")
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/member")

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/LoginRequestDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/LoginRequestDto.java
@@ -1,11 +1,17 @@
 package com.pyonsnalcolor.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
+@Schema(description = "OAuth 로그인용 Request DTO")
 @Getter
 @NoArgsConstructor
 public class LoginRequestDto {
 
+    @Schema(description = "OAuth 로그인 후 받은 토큰")
+    @NotBlank
     private String token;
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/LoginResponseDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/LoginResponseDto.java
@@ -1,19 +1,27 @@
 package com.pyonsnalcolor.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
+@Schema(description = "OAuth 로그인 후 Response DTO", required = true)
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoginResponseDto {
 
-    private Boolean isFirstLogin; // 최초 로그인(회원가입)인지, 다시 로그인(로그아웃 후)인지 구분
+    @Schema(description = "최초 로그인(회원가입)인지, 다시 로그인(로그아웃 후)인지 구분용", required = true)
+    @NotBlank
+    private Boolean isFirstLogin;
 
+    @NotBlank
     private String accessToken;
 
+    @NotBlank
     private String refreshToken;
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/MemberInfoResponseDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/MemberInfoResponseDto.java
@@ -1,25 +1,36 @@
 package com.pyonsnalcolor.auth.dto;
 
 import com.pyonsnalcolor.member.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+import javax.validation.constraints.NotBlank;
+
+@Schema(description = "사용자 정보 Response DTO")
 @Getter
 public class MemberInfoResponseDto {
 
+    @Schema(description = "OAuth ID", example = "apple-user@gmail.com")
+    @NotBlank
+    private String oauthId;
+
+    @Schema(description = "OAuth 타입", example = "APPLE")
+    @NotBlank
+    private String oauthType;
+
+    @NotBlank
     private Long memberId;
 
-    private String oAuthId;
-
-    private String oAuthType;
-
+    @NotBlank
     private String nickname;
 
+    @NotBlank
     private String email;
 
     public MemberInfoResponseDto(Member member) {
         this.memberId  = member.getId();
-        this.oAuthId = member.getOAuthId();
-        this.oAuthType = member.getOAuthType().toString();
+        this.oauthId = member.getOAuthId();
+        this.oauthType = member.getOAuthType().toString();
         this.nickname  = member.getNickname();
         this.email  = member.getEmail();
     }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/NicknameRequestDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/NicknameRequestDto.java
@@ -1,16 +1,19 @@
 package com.pyonsnalcolor.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Pattern;
 
+@Schema(description = "변경할 닉네임 Request DTO")
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class NicknameRequestDto {
 
+    @Schema(description = "변경할 닉네임, 특수문자 제외 15자 이내", required = true)
     @Pattern(regexp="^[0-9a-zA-Zㄱ-ㅎ가-힣 ]{1,15}", message = "닉네임은 특수 문자가 허용되지 않고 15자 이내이어야 합니다.")
     private String nickname;
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/TokenDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/TokenDto.java
@@ -2,13 +2,17 @@ package com.pyonsnalcolor.auth.dto;
 
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
+
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class TokenDto {
 
+    @NotBlank
     private String accessToken;
 
+    @NotBlank
     private String refreshToken;
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/controller/EventBatchController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/controller/EventBatchController.java
@@ -1,17 +1,21 @@
 package com.pyonsnalcolor.batch.controller;
 
 import com.pyonsnalcolor.batch.service.EventBatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "이벤트 상품 배치용 api", description = "관리자용 수동으로 크롤링하는 용도")
 @RestController
 public class EventBatchController {
     @Autowired
     private List<EventBatchService> batchServiceList;
 
+    @Operation(summary = "이벤트 상품 업데이트", description = "지난 이벤트 상품 삭제하고 새 이벤트 상품 저장합니다.")
     @GetMapping("/manage/event-products/execute")
     public void executeEventBatch() {
         for (EventBatchService eventBatchService : batchServiceList) {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/controller/PbBatchController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/controller/PbBatchController.java
@@ -1,18 +1,21 @@
 package com.pyonsnalcolor.batch.controller;
 
 import com.pyonsnalcolor.batch.service.PbBatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "PB 상품 배치용 api", description = "관리자용 수동으로 크롤링하는 용도")
 @RestController
 public class PbBatchController {
     @Autowired
     private List<PbBatchService> batchServiceList;
 
-
+    @Operation(summary = "PB 상품 업데이트", description = "새 PB 상품 저장합니다.")
     @GetMapping("/manage/pb-products/execute")
     public void executePbBatch() {
         for (PbBatchService pbBatchService : batchServiceList) {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuDescriptionBatch.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuDescriptionBatch.java
@@ -1,0 +1,43 @@
+package com.pyonsnalcolor.batch.service.cu;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+public interface CuDescriptionBatch {
+
+    String CU_DESCRIPTION_PAGE_URL = "https://cu.bgfretail.com/product/view.do";
+    int TIMEOUT = 5000;
+
+    default String getDescription(Element element, String productType) throws Exception {
+        String productCode = getProductCode(element);
+
+        try {
+            String detailPage = UriComponentsBuilder
+                    .fromUriString(CU_DESCRIPTION_PAGE_URL)
+                    .queryParam("category", productType)
+                    .queryParam("gdIdx", productCode)
+                    .build()
+                    .toString();
+            Document doc = Jsoup.connect(detailPage).timeout(TIMEOUT).get();
+            Elements elements = doc.select("ul.prodExplain li");
+            return elements.text();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("URL 주소가 유효하지 않습니다.");
+        } catch (SocketTimeoutException e) {
+            throw new SocketTimeoutException("연결 시간이 초과하였습니다.");
+        } catch (IOException e) {
+            throw new IOException("연결에 실패하였습니다.");
+        }
+    }
+
+    default String getProductCode(Element element) {
+        String originProductElement = element.select("a").first().attr("href");
+        return originProductElement.split("\\(")[1].split("\\)")[0];
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
@@ -67,7 +67,7 @@ public class CuPbBatchService extends PbBatchService implements CuDescriptionBat
                     .map(this::convertToBasePbProduct)
                     .collect(Collectors.toList());
             products.addAll(pagedProducts);
-            pageIndex++;
+            pageIndex += 1;
         }
         return products;
     }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
@@ -66,7 +66,7 @@ public class SevenEventBatchService extends EventBatchService {
 
             List<BaseEventProduct> pagedProducts = sevenEventTab.getPagedProducts(elements, detailPageElements);
             products.addAll(pagedProducts);
-            pageIndex++;
+            pageIndex += 1;
         }
         return products;
     }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
@@ -61,7 +61,7 @@ public class SevenPbBatchService extends PbBatchService {
                     .map(this::convertToBasePbProduct)
                     .collect(Collectors.toList());
             products.addAll(pagedProducts);
-            pageIndex++;
+            pageIndex += 1;
         }
         return products;
     }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.pyonsnalcolor.product.entity.UUIDGenerator.generateId;
+
 @Service("SevenPb")
 @Slf4j
 public class SevenPbBatchService extends PbBatchService {
@@ -70,6 +72,7 @@ public class SevenPbBatchService extends PbBatchService {
         String price = element.select("div.price").text();
 
         return BasePbProduct.builder()
+                .id(generateId())
                 .name(name)
                 .image(image)
                 .price(price)

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/EventProductController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/EventProductController.java
@@ -11,17 +11,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "EventProductController", description = "행사 상품 api")
+@Tag(name = "이벤트 상품 api")
 @RestController
 @RequiredArgsConstructor
 public class EventProductController {
     private final EventProductService eventProductService;
 
-    @Operation(summary = "행사 상품 조회", description = "행사 상품을 조회합니다.")
+    @Operation(summary = "이벤트 상품 조회", description = "이벤트 상품을 조회합니다.")
     @Parameter(name = "pageNumber", description = "조회할 페이지 번호")
     @Parameter(name = "pageSize", description = "페이지별 상품 갯수")
-    @Parameter(name = "storeType", description = "편의점 종류, default는 모든 편의점")
-    @Parameter(name = "sorted", description = "정렬순서, default는 최신순")
+    @Parameter(name = "storeType", description = "편의점 종류(seven_eleven, cu, gs25, emart24, all)")
+    @Parameter(name = "sorted", description = "정렬순서")
     @GetMapping("/products/event-products")
     public Page<BaseEventProduct> getEventProducts(@RequestParam("pageNumber") int pageNumber,
                                                    @RequestParam("pageSize") int pageSize,

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/PbProductController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/PbProductController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "PbProductController", description = "PB 상품 api")
+@Tag(name = "PB 상품 api")
 @RestController
 @RequiredArgsConstructor
 public class PbProductController {
@@ -21,8 +21,8 @@ public class PbProductController {
     @Operation(summary = "PB 상품 조회", description = "PB 상품을 조회합니다.")
     @Parameter(name = "pageNumber", description = "조회할 페이지 번호")
     @Parameter(name = "pageSize", description = "페이지별 상품 갯수")
-    @Parameter(name = "storeType", description = "편의점 종류, default는 모든 편의점")
-    @Parameter(name = "sorted", description = "정렬순서, default는 최신순")
+    @Parameter(name = "storeType", description = "편의점 종류(seven_eleven, cu, gs25, emart24, all)")
+    @Parameter(name = "sorted", description = "정렬순서")
     @GetMapping("/products/pb-products")
     public Page<BasePbProduct> getPbProducts(@RequestParam("pageNumber") int pageNumber,
                                              @RequestParam("pageSize") int pageSize,

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/auth/service/MemberServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/auth/service/MemberServiceTest.java
@@ -103,8 +103,8 @@ class MemberServiceTest {
         // then
         Assertions.assertAll(
                 () -> assertEquals(memberInfoResponseDto.getEmail(), email),
-                () -> assertEquals(memberInfoResponseDto.getOAuthId(), oAuthId),
-                () -> assertEquals(memberInfoResponseDto.getOAuthType(), oAuthType.toString())
+                () -> assertEquals(memberInfoResponseDto.getOauthId(), oAuthId),
+                () -> assertEquals(memberInfoResponseDto.getOauthType(), oAuthType.toString())
         );
     }
 

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchServiceTest.java
@@ -1,0 +1,22 @@
+package com.pyonsnalcolor.batch.service.cu;
+
+import com.pyonsnalcolor.batch.service.BatchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CuEventBatchServiceTest {
+
+    @Autowired
+    @Qualifier("CuEvent")
+    private BatchService batchService;
+
+    @Test
+    @DisplayName("CU 이벤트 상품 전체 플로우 실행")
+    void integrationTest() {
+        batchService.execute();
+    }
+}

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchServiceTest.java
@@ -1,0 +1,22 @@
+package com.pyonsnalcolor.batch.service.cu;
+
+import com.pyonsnalcolor.batch.service.BatchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CuPbBatchServiceTest {
+
+    @Autowired
+    @Qualifier("CuPb")
+    private BatchService batchService;
+
+    @Test
+    @DisplayName("CU PB 상품 전체 플로우 실행")
+    void integrationTest() {
+        batchService.execute();
+    }
+}

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchServiceTest.java
@@ -1,0 +1,22 @@
+package com.pyonsnalcolor.batch.service.seven;
+
+import com.pyonsnalcolor.batch.service.BatchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SevenEventBatchServiceTest {
+
+    @Autowired
+    @Qualifier("SevenEvent")
+    private BatchService batchService;
+
+    @Test
+    @DisplayName("세븐일레븐 이벤트 상품 전체 플로우 실행")
+    void integrationTest() {
+        batchService.execute();
+    }
+}

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchServiceTest.java
@@ -1,0 +1,22 @@
+package com.pyonsnalcolor.batch.service.seven;
+
+import com.pyonsnalcolor.batch.service.BatchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SevenPbBatchServiceTest {
+
+    @Autowired
+    @Qualifier("SevenPb")
+    private BatchService batchService;
+
+    @Test
+    @DisplayName("세븐일레븐 PB 상품 전체 플로우 실행")
+    void integrationTest() {
+        batchService.execute();
+    }
+}

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
@@ -32,4 +32,5 @@ public class BaseProduct {
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime updatedTime;
+    private String description;
 }


### PR DESCRIPTION
### 구현 사항
- BaseProduct에 description 필드 추가
- CU PB, 이벤트 상품 상세 정보 조회 기능 구현 (상세정보는 CU에만 있습니다)
- CU, 세븐일레븐 통합 테스트 추가
- CU 이벤트 타입 찾는 기능 버그 수정

### 참고 사항
- **예외 처리**(일단 다른 쪽은 안 건들고 상세 정보 페이지 들어가서 조회하는 쪽만 해놨습니다)
  1번) `getDescription`(상세 페이지 접근 조회하는 메소드)에서는 예외 유형별로 Exception 던지고
  2번) `getDescription` 호출하는 곳에서는 try-catch로 잡고 log.error로 로그 남기도록 했습니다
=> 배치 전반적으로 예외 처리할 방향 생각중이시면 이 부분 수정해도 좋을 것 같아요
 
![image](https://github.com/YAPP-Github/pyonsnalcolor-server/assets/77563814/97fac011-3485-4440-b0b3-0abc2c5a64c8)

- CU 이벤트 상품만 뒷 페이지들로 갈 수록 긴 로딩 시간이 필요해서 TIMEOUT 15초으로 설정했습니다(최소 테스트O)