### PR TITLE
Feature/push 푸시 구독 목록/키워드 관련 기능 구현

### DIFF
--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/ApiApplication.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/ApiApplication.java
@@ -1,10 +1,13 @@
 package com.pyonsnalcolor;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@OpenAPIDefinition(servers = {@Server(url = "/")})
 @SpringBootApplication
 @EnableScheduling
 @EnableFeignClients

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/admin/AdminController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/admin/AdminController.java
@@ -1,0 +1,23 @@
+package com.pyonsnalcolor.admin;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "관리자용 api")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AdminController {
+
+    @Operation(summary = "EC2 헬스체크용")
+    @GetMapping("/health-check")
+    public ResponseEntity getHealthCheck() {
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/MemberController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/MemberController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 @Tag(name = "(인증 제외)사용자 관련 api")
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/member")
 public class MemberController {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/service/MemberService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/service/MemberService.java
@@ -13,6 +13,7 @@ import com.pyonsnalcolor.auth.dto.TokenDto;
 import com.pyonsnalcolor.auth.AuthUserDetails;
 import com.pyonsnalcolor.auth.jwt.JwtTokenProvider;
 import com.pyonsnalcolor.member.MemberRepository;
+import com.pyonsnalcolor.push.service.PushProductStoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +40,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtil redisUtil;
+    private final PushProductStoreService pushProductStoreService;
 
     public LoginResponseDto oAuthLogin(OAuthType oAuthType, String email) {
         String oauthId = oAuthType.addOAuthTypeHeaderWithEmail(email);
@@ -74,6 +76,7 @@ public class MemberService {
                 .role(Role.ROLE_USER)
                 .build();
         memberRepository.save(member);
+        pushProductStoreService.createPushProductStores(member);
 
         return LoginResponseDto.builder()
                 .accessToken(accessToken)

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/CorsConfig.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.pyonsnalcolor.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOriginPattern("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/SecurityConfig.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
         return (web) -> web.ignoring()
                 .antMatchers( "/resources/**",
                         "/v3/api-docs/**",
-                        "/swagger-ui/**"
+                        "/swagger-ui/**",
+                        "/health-check"
                 );
     }
 

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/SwaggerConfig.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,6 +29,7 @@ public class SwaggerConfig {
                 .addList("Refresh");
 
         return new OpenAPI()
+                .addServersItem(new Server().url("/"))
                 .components(new Components()
                         .addSecuritySchemes("Authorization", bearerAuth)
                         .addSecuritySchemes("Refresh", bearerRefresh))

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/PyonsnalcolorPushException.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/PyonsnalcolorPushException.java
@@ -1,0 +1,10 @@
+package com.pyonsnalcolor.exception;
+
+import com.pyonsnalcolor.exception.model.ErrorCode;
+
+public class PyonsnalcolorPushException extends PyonsnalcolorException{
+
+    public PyonsnalcolorPushException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/model/CommonErrorCode.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/model/CommonErrorCode.java
@@ -4,13 +4,15 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 
 @Getter
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
 
-    SERVER_UNAVAILABLE(SERVICE_UNAVAILABLE, "서버에 오류가 발생하였습니다.");
+    SERVER_UNAVAILABLE(SERVICE_UNAVAILABLE, "서버에 오류가 발생하였습니다."),
+    INVALID_PARAMETER(BAD_REQUEST, "입력값이 형식에 맞지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/model/PushErrorCode.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/model/PushErrorCode.java
@@ -8,9 +8,10 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @RequiredArgsConstructor
-public enum PushKeywordErrorCode implements ErrorCode {
+public enum PushErrorCode implements ErrorCode {
 
-    INVALID_KEYWORD_FORMAT(BAD_REQUEST, "키워드가 형식에 맞지 않습니다."),
+    KEYWORD_ALREADY_EXIST(BAD_REQUEST, "이미 존재하는 키워드입니다."),
+    KEYWORD_NOT_EXIST(BAD_REQUEST, "키워드가 존재하지 않습니다."),
     KEYWORD_LIMIT_EXCEEDED(BAD_REQUEST, "등록 가능한 키워드 수를 초과하였습니다.");
 
     private final HttpStatus httpStatus;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushKeywordController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushKeywordController.java
@@ -1,0 +1,58 @@
+package com.pyonsnalcolor.push.controller;
+
+import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.push.dto.PushKeywordRequestDto;
+import com.pyonsnalcolor.push.dto.PushKeywordResponseDto;
+import com.pyonsnalcolor.push.service.PushKeywordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@Tag(name = "푸시 키워드 관련 api")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/push/keyword")
+public class PushKeywordController {
+
+    private final PushKeywordService pushKeywordService;
+
+    @Operation(summary = "푸시 키워드 목록 조회")
+    @GetMapping
+    public ResponseEntity<List<PushKeywordResponseDto>> getPushKeyword(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal AuthUserDetails authUserDetails
+    ) {
+        List<PushKeywordResponseDto> result = pushKeywordService.getPushKeywordResponseDto(authUserDetails);
+        return new ResponseEntity(result, HttpStatus.OK);
+    }
+
+    @Operation(summary = "푸시 키워드 등록", description = "띄어쓰기, 특수문자없이 10자 이내")
+    @PostMapping
+    public ResponseEntity createPushKeyword(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @Valid @RequestBody PushKeywordRequestDto pushKeywordRequestDto
+    ) {
+        pushKeywordService.createPushKeyword(authUserDetails, pushKeywordRequestDto);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @Operation(summary = "푸시 키워드 삭제")
+    @DeleteMapping("/{keywordId}")
+    public ResponseEntity deletePushKeyword(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @PathVariable Long keywordId
+    ) {
+        pushKeywordService.deletePushKeyword(authUserDetails, keywordId);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushProductStoreController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushProductStoreController.java
@@ -1,0 +1,57 @@
+package com.pyonsnalcolor.push.controller;
+
+import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.push.dto.PushProductStoreRequestDto;
+import com.pyonsnalcolor.push.dto.PushProductStoreResponseDto;
+import com.pyonsnalcolor.push.service.PushProductStoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "푸시 구독 목록 관련 api")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/push/stores")
+public class PushProductStoreController {
+
+    private final PushProductStoreService pushProductStoreService;
+
+    @Operation(summary = "구독 목록 조회", description = "편의점/상품별 구독 현황을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<PushProductStoreResponseDto>> getPushProductStores(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal AuthUserDetails authUserDetails
+    ) {
+        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(authUserDetails);
+        return new ResponseEntity(result, HttpStatus.OK);
+    }
+
+    @Operation(summary = "구독 신청", description = "편의점/상품별 구독을 신청합니다.")
+    @PatchMapping("/subscribe")
+    public ResponseEntity subscribePushProductStores(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @RequestBody PushProductStoreRequestDto pushProductStoreRequestDto
+    ) {
+        pushProductStoreService.subscribePushProductStores(authUserDetails, pushProductStoreRequestDto);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @Operation(summary = "구독 취소", description = "편의점/상품별 구독을 취소합니다.")
+    @DeleteMapping("/unsubscribe")
+    public ResponseEntity unsubscribePushProductStores(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @RequestBody PushProductStoreRequestDto pushProductStoreRequestDto
+    ) {
+        pushProductStoreService.unsubscribePushProductStores(authUserDetails, pushProductStoreRequestDto);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushRecordController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushRecordController.java
@@ -1,0 +1,13 @@
+package com.pyonsnalcolor.push.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/push/record")
+public class PushRecordController {
+
+    // 기록 조회
+
+    // 기록 등록
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/DeviceTokenRequestDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/DeviceTokenRequestDto.java
@@ -1,4 +1,4 @@
-package com.pyonsnalcolor.alarm.dto;
+package com.pyonsnalcolor.push.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/FcmMessageType.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/FcmMessageType.java
@@ -1,4 +1,4 @@
-package com.pyonsnalcolor.alarm.dto;
+package com.pyonsnalcolor.push.dto;
 
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushKeywordRequestDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushKeywordRequestDto.java
@@ -1,0 +1,22 @@
+package com.pyonsnalcolor.push.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushKeywordRequestDto {
+
+    @Schema(description = "저장할 푸시 알림 키워드 이름")
+    @Pattern(regexp="^[0-9a-zA-Zㄱ-ㅎ가-힣]{1,10}", message = "공백과 특수 문자 제외 10자 이내이어야 합니다.")
+    @NotBlank
+    private String name;
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushKeywordRequestDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushKeywordRequestDto.java
@@ -9,13 +9,14 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
+@Schema(description = "푸시 알림 키워드 등록/삭제용 Request DTO")
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PushKeywordRequestDto {
 
-    @Schema(description = "저장할 푸시 알림 키워드 이름")
+    @Schema(description = "저장할 푸시 알림 키워드 이름(공백X, 특수문자 제외 10자 이내)", example = "콜라")
     @Pattern(regexp="^[0-9a-zA-Zㄱ-ㅎ가-힣]{1,10}", message = "공백과 특수 문자 제외 10자 이내이어야 합니다.")
     @NotBlank
     private String name;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushKeywordResponseDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushKeywordResponseDto.java
@@ -1,0 +1,25 @@
+package com.pyonsnalcolor.push.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Schema(description = "푸시 키워드 목록 Response DTO")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushKeywordResponseDto {
+
+    @Schema(description = "푸시 알림 키워드 id")
+    @NotBlank
+    private Long id;
+
+    @Schema(description = "푸시 알림 키워드 이름")
+    @NotBlank
+    private String name;
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushProductStoreRequestDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushProductStoreRequestDto.java
@@ -1,6 +1,6 @@
 package com.pyonsnalcolor.push.dto;
 
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,13 +9,14 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotBlank;
 import java.util.List;
 
+@Schema(description = "푸시 구독 신청/취소용 Request DTO")
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PushProductStoreRequestDto {
 
-    @Parameter(example = "{ \"pushProductStores\": [\"PB_GS25\", \"EVENT_EMART24\"]}")
+    @Schema(description = "상품종류_편의점명 리스트", example = "{ \"pushProductStores\": [\"PB_GS25\", \"EVENT_CU\"]}")
     @NotBlank
-    private List<String> pushProductStores;
+    private List<String> productStores;
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushProductStoreRequestDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushProductStoreRequestDto.java
@@ -1,0 +1,21 @@
+package com.pyonsnalcolor.push.dto;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushProductStoreRequestDto {
+
+    @Parameter(example = "{ \"pushProductStores\": [\"PB_GS25\", \"EVENT_EMART24\"]}")
+    @NotBlank
+    private List<String> pushProductStores;
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushProductStoreResponseDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushProductStoreResponseDto.java
@@ -15,11 +15,11 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class PushProductStoreResponseDto {
 
-    @Schema(description = "편의점, 상품별 이름", example = "EVENT_CU")
+    @Schema(description = "상품종류_편의점명", example = "EVENT_CU")
     @NotBlank
     private String productStore;
 
-    @Schema(description = "구독 여부")
+    @Schema(description = "구독 여부", example = "true")
     @NotBlank
     private Boolean isSubscribed;
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushProductStoreResponseDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/dto/PushProductStoreResponseDto.java
@@ -1,0 +1,25 @@
+package com.pyonsnalcolor.push.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Schema(description = "편의점,상품별 구독목록 현황 Response DTO")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushProductStoreResponseDto {
+
+    @Schema(description = "편의점, 상품별 이름", example = "EVENT_CU")
+    @NotBlank
+    private String productStore;
+
+    @Schema(description = "구독 여부")
+    @NotBlank
+    private Boolean isSubscribed;
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/fcm/FcmController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/fcm/FcmController.java
@@ -1,6 +1,6 @@
-package com.pyonsnalcolor.alarm.fcm;
+package com.pyonsnalcolor.push.fcm;
 
-import com.pyonsnalcolor.alarm.dto.DeviceTokenRequestDto;
+import com.pyonsnalcolor.push.dto.DeviceTokenRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/fcm/FcmPushService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/fcm/FcmPushService.java
@@ -1,11 +1,11 @@
-package com.pyonsnalcolor.alarm.fcm;
+package com.pyonsnalcolor.push.fcm;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
-import com.pyonsnalcolor.alarm.dto.DeviceTokenRequestDto;
+import com.pyonsnalcolor.push.dto.DeviceTokenRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
-import static com.pyonsnalcolor.alarm.dto.FcmMessageType.PB;
+import static com.pyonsnalcolor.push.dto.FcmMessageType.PB;
 
 @Slf4j
 @Service

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/repository/PushKeywordRepository.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/repository/PushKeywordRepository.java
@@ -1,0 +1,20 @@
+package com.pyonsnalcolor.push.repository;
+
+import com.pyonsnalcolor.member.Member;
+import com.pyonsnalcolor.push.PushKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PushKeywordRepository extends JpaRepository<PushKeyword, Long> {
+
+    List<PushKeyword> findByMember(Member member);
+
+    Optional<PushKeyword> findByMemberAndId(Member member, Long id);
+
+    Optional<PushKeyword> findByMemberAndName(Member member, String name);
+
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/repository/PushProductStoreRepository.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/repository/PushProductStoreRepository.java
@@ -1,0 +1,17 @@
+package com.pyonsnalcolor.push.repository;
+
+import com.pyonsnalcolor.member.Member;
+import com.pyonsnalcolor.product.enumtype.ProductStoreType;
+import com.pyonsnalcolor.push.PushProductStore;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PushProductStoreRepository extends JpaRepository<PushProductStore, Long>{
+
+    List<PushProductStore> findByMember(Member member);
+
+    PushProductStore findByMemberAndProductStoreType(Member member, ProductStoreType productStoreType);
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushKeywordService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushKeywordService.java
@@ -1,0 +1,71 @@
+package com.pyonsnalcolor.push.service;
+
+import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.exception.PyonsnalcolorPushException;
+import com.pyonsnalcolor.member.Member;
+import com.pyonsnalcolor.push.PushKeyword;
+import com.pyonsnalcolor.push.dto.PushKeywordRequestDto;
+import com.pyonsnalcolor.push.dto.PushKeywordResponseDto;
+import com.pyonsnalcolor.push.repository.PushKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.pyonsnalcolor.exception.model.PushErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class PushKeywordService {
+
+    private final PushKeywordRepository pushKeywordRepository;
+    private static final int PUSH_KEYWORD_NUMBER = 3;
+
+    public PushKeyword createPushKeyword(AuthUserDetails authUserDetails, PushKeywordRequestDto pushKeywordRequestDto) {
+        Member member = authUserDetails.getMember();
+        String pushKeywordName = pushKeywordRequestDto.getName();
+
+        validatePushKeywordExist(member, pushKeywordName);
+        validatePushKeywordNumber(member);
+
+        PushKeyword newPushKeyword = PushKeyword.builder()
+                .member(member)
+                .name(pushKeywordName)
+                .build();
+        return pushKeywordRepository.save(newPushKeyword);
+    }
+
+    private void validatePushKeywordExist(Member member, String pushKeywordName) {
+        pushKeywordRepository.findByMemberAndName(member, pushKeywordName)
+                .ifPresent( p -> {
+                    throw new PyonsnalcolorPushException(KEYWORD_ALREADY_EXIST);
+                });
+    }
+
+    private void validatePushKeywordNumber(Member member) {
+        List<PushKeyword> result = pushKeywordRepository.findByMember(member);
+        if (result.size() >= PUSH_KEYWORD_NUMBER) {
+            throw new PyonsnalcolorPushException(KEYWORD_LIMIT_EXCEEDED);
+        }
+    }
+
+    public void deletePushKeyword(AuthUserDetails authUserDetails, Long keywordId) {
+        Member member = authUserDetails.getMember();
+        PushKeyword pushKeyword = pushKeywordRepository.findByMemberAndId(member, keywordId)
+                .orElseThrow(() -> new PyonsnalcolorPushException(KEYWORD_NOT_EXIST));
+        pushKeywordRepository.delete(pushKeyword);
+    }
+
+    public List<PushKeywordResponseDto> getPushKeywordResponseDto(AuthUserDetails authUserDetails) {
+        Member member = authUserDetails.getMember();
+        List<PushKeyword> pushKeywords = pushKeywordRepository.findByMember(member);
+
+        return  pushKeywords.stream()
+                .map(pushKeyword -> PushKeywordResponseDto.builder()
+                        .id(pushKeyword.getId())
+                        .name(pushKeyword.getName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushProductStoreService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushProductStoreService.java
@@ -68,7 +68,7 @@ public class PushProductStoreService {
             PushProductStoreRequestDto pushProductStoreRequestDtos,
             boolean updatedSubscribedStatus)
     {
-        pushProductStoreRequestDtos.getPushProductStores().stream()
+        pushProductStoreRequestDtos.getProductStores().stream()
                 .map(pushProductStoreString -> {
                     PushProductStore pushProductStore = pushProductStoreRepository
                             .findByMemberAndProductStoreType(member, ProductStoreType.valueOf(pushProductStoreString));

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushProductStoreService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushProductStoreService.java
@@ -1,0 +1,80 @@
+package com.pyonsnalcolor.push.service;
+
+import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.member.Member;
+import com.pyonsnalcolor.product.enumtype.ProductStoreType;
+import com.pyonsnalcolor.push.PushProductStore;
+import com.pyonsnalcolor.push.dto.PushProductStoreRequestDto;
+import com.pyonsnalcolor.push.dto.PushProductStoreResponseDto;
+import com.pyonsnalcolor.push.repository.PushProductStoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PushProductStoreService {
+
+    private final PushProductStoreRepository pushProductStoreRepository;
+
+    public void createPushProductStores (Member member) {
+        List<PushProductStore> pushProductStores = Arrays.stream(ProductStoreType.values())
+                .map( i -> PushProductStore.builder()
+                        .productStoreType(i)
+                        .member(member)
+                        .isSubscribed(true)
+                        .updatedTime(LocalDateTime.now())
+                        .build())
+                .collect(Collectors.toList());
+        pushProductStoreRepository.saveAll(pushProductStores);
+    }
+
+    public List<PushProductStoreResponseDto> getPushProductStores (AuthUserDetails authUserDetails) {
+        Member member = authUserDetails.getMember();
+        List<PushProductStore> pushProductStores = pushProductStoreRepository.findByMember(member);
+
+        return pushProductStores.stream()
+                .map(p -> {
+                    return PushProductStoreResponseDto.builder()
+                            .productStore(p.getProductStoreType().name())
+                            .isSubscribed(p.isSubscribed())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    public void subscribePushProductStores (
+            AuthUserDetails authUserDetails,
+            PushProductStoreRequestDto pushProductStoreRequestDtos)
+    {
+        Member member = authUserDetails.getMember();
+        updateSubscribedStatus(member, pushProductStoreRequestDtos, true);
+    }
+
+    public void unsubscribePushProductStores (
+            AuthUserDetails authUserDetails,
+            PushProductStoreRequestDto pushProductStoreRequestDtos)
+    {
+        Member member = authUserDetails.getMember();
+        updateSubscribedStatus(member, pushProductStoreRequestDtos, false);
+    }
+
+    private void updateSubscribedStatus(
+            Member member,
+            PushProductStoreRequestDto pushProductStoreRequestDtos,
+            boolean updatedSubscribedStatus)
+    {
+        pushProductStoreRequestDtos.getPushProductStores().stream()
+                .map(pushProductStoreString -> {
+                    PushProductStore pushProductStore = pushProductStoreRepository
+                            .findByMemberAndProductStoreType(member, ProductStoreType.valueOf(pushProductStoreString));
+                    pushProductStore.updateSubscribedStatus(updatedSubscribedStatus);
+                    return pushProductStore;
+                })
+                .forEach(pushProductStoreRepository::save);
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushRecordService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushRecordService.java
@@ -1,0 +1,13 @@
+package com.pyonsnalcolor.push.service;
+
+import com.pyonsnalcolor.push.repository.PushKeywordRepository;
+import com.pyonsnalcolor.push.repository.PushRecordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PushRecordService {
+
+    @Autowired
+    PushRecordRepository pushRecordRepository;
+}

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushKeywordServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushKeywordServiceTest.java
@@ -1,0 +1,134 @@
+package com.pyonsnalcolor.push.service;
+
+import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.exception.PyonsnalcolorPushException;
+import com.pyonsnalcolor.member.Member;
+import com.pyonsnalcolor.member.MemberRepository;
+import com.pyonsnalcolor.member.enumtype.OAuthType;
+import com.pyonsnalcolor.member.enumtype.Role;
+import com.pyonsnalcolor.push.PushKeyword;
+import com.pyonsnalcolor.push.dto.PushKeywordRequestDto;
+import com.pyonsnalcolor.push.repository.PushKeywordRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+@Transactional
+@SpringBootTest
+class PushKeywordServiceTest {
+
+    @Autowired
+    private PushKeywordService pushKeywordService;
+
+    @Autowired
+    private PushKeywordRepository pushKeywordRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("푸시 키워드를 조회합니다.")
+    @Test
+    void savePushKeyword() {
+        Member member =  Member.builder()
+                .email("sample@gmail.com")
+                .OAuthType(OAuthType.APPLE)
+                .oAuthId("apple-sample@gmail.com")
+                .refreshToken("refreshToken")
+                .role(Role.ROLE_USER).build();
+        memberRepository.save(member);
+        AuthUserDetails authUserDetails = getAuthentication(member);
+        pushKeywordService.createPushKeyword(authUserDetails, new PushKeywordRequestDto("포켓몬"));
+        pushKeywordService.createPushKeyword(authUserDetails, new PushKeywordRequestDto("짱구"));
+        pushKeywordService.createPushKeyword(authUserDetails, new PushKeywordRequestDto("제로"));
+
+        List<PushKeyword> result = pushKeywordRepository.findByMember(member);
+
+        assertAll(
+                () -> assertThat(result.size()).isEqualTo(3),
+                () -> assertThat(result.contains("포켓몬")),
+                () -> assertThat(result.contains("짱구")),
+                () -> assertThat(result.contains("제로")));
+    }
+
+    @DisplayName("잘못된 형식의 푸시 키워드를 저장할 경우 예외를 반환합니다.")
+    @Test
+    void invalidateFormatOfPushKeyword() {
+        Member member =  Member.builder()
+                .email("sample@gmail.com")
+                .OAuthType(OAuthType.APPLE)
+                .oAuthId("apple-sample@gmail.com")
+                .refreshToken("refreshToken")
+                .role(Role.ROLE_USER).build();
+        memberRepository.save(member);
+        AuthUserDetails authUserDetails = getAuthentication(member);
+
+        PushKeywordRequestDto pushKeywordRequestDto = PushKeywordRequestDto.builder().name("!@초코").build();
+
+        assertThatThrownBy(() -> pushKeywordService.createPushKeyword(authUserDetails, pushKeywordRequestDto))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @DisplayName("이미 저장한 푸시 키워드일 경우 예외를 반환합니다.")
+    @Test
+    void duplicatePushKeyword() {
+        Member member =  Member.builder()
+                .email("sample@gmail.com")
+                .OAuthType(OAuthType.APPLE)
+                .oAuthId("apple-sample@gmail.com")
+                .refreshToken("refreshToken")
+                .role(Role.ROLE_USER).build();
+        memberRepository.save(member);
+        AuthUserDetails authUserDetails = getAuthentication(member);
+
+        PushKeywordRequestDto pushKeywordRequestDto = PushKeywordRequestDto.builder().name("초코").build();
+        pushKeywordService.createPushKeyword(authUserDetails, pushKeywordRequestDto);
+
+        assertThatThrownBy(() -> pushKeywordService.createPushKeyword(authUserDetails, pushKeywordRequestDto))
+                .isInstanceOf(PyonsnalcolorPushException.class);
+    }
+
+
+    @DisplayName("3개 이상의 푸시 키워드를 저장할 경우 예외를 반환합니다.")
+    @Test
+    void exceedLimitOfPushKeywordNumber() {
+        Member member =  Member.builder().email("sample@gmail.com")
+                .OAuthType(OAuthType.APPLE)
+                .oAuthId("apple-sample@gmail.com")
+                .refreshToken("refreshToken")
+                .role(Role.ROLE_USER).build();
+        memberRepository.save(member);
+        AuthUserDetails authUserDetails = getAuthentication(member);
+
+        pushKeywordService.createPushKeyword(authUserDetails, new PushKeywordRequestDto("포켓몬"));
+        pushKeywordService.createPushKeyword(authUserDetails, new PushKeywordRequestDto("짱구"));
+        pushKeywordService.createPushKeyword(authUserDetails, new PushKeywordRequestDto("제로"));
+
+        assertThatThrownBy(() -> pushKeywordService
+                .createPushKeyword(authUserDetails, new PushKeywordRequestDto("슈가")))
+                .isInstanceOf(PyonsnalcolorPushException.class);
+    }
+
+    // CustomUserDetails로 Member 객체를 매핑하기 때문에 필요 - 이후 수정
+    private AuthUserDetails getAuthentication(Member member){
+        SecurityContext context = SecurityContextHolder.getContext();
+        AuthUserDetails authUserDetails = new AuthUserDetails(member);
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                authUserDetails,
+                "",
+                authUserDetails.getAuthorities()));
+        return authUserDetails;
+    }
+}

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushProductStoreServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushProductStoreServiceTest.java
@@ -69,7 +69,7 @@ class PushProductStoreServiceTest {
         AuthUserDetails authUserDetails = getAuthentication(member);
 
         PushProductStoreRequestDto requestDto = PushProductStoreRequestDto.builder()
-                .pushProductStores(List.of("EVENT_CU", "PB_CU"))
+                .productStores(List.of("EVENT_CU", "PB_CU"))
                 .build();
 
         pushProductStoreService.unsubscribePushProductStores(authUserDetails, requestDto);

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushProductStoreServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushProductStoreServiceTest.java
@@ -1,0 +1,95 @@
+package com.pyonsnalcolor.push.service;
+
+import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.member.Member;
+import com.pyonsnalcolor.member.MemberRepository;
+import com.pyonsnalcolor.member.enumtype.OAuthType;
+import com.pyonsnalcolor.member.enumtype.Role;
+import com.pyonsnalcolor.push.dto.PushProductStoreRequestDto;
+import com.pyonsnalcolor.push.dto.PushProductStoreResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Transactional
+@SpringBootTest
+class PushProductStoreServiceTest {
+
+    @Autowired
+    private PushProductStoreService pushProductStoreService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("회원가입하면 모든 편의점을 구독 신청합니다.")
+    @Test
+    void getPushProductStores() {
+        Member member =  Member.builder()
+                .email("sample@gmail.com")
+                .OAuthType(OAuthType.APPLE)
+                .oAuthId("apple-sample@gmail.com")
+                .refreshToken("refreshToken")
+                .role(Role.ROLE_USER).build();
+        memberRepository.save(member);
+        pushProductStoreService.createPushProductStores(member);
+        AuthUserDetails authUserDetails = getAuthentication(member);
+
+        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(authUserDetails);
+
+        assertAll(
+                () -> assertThat(result.size()).isEqualTo(8),
+                () -> assertThat(result).extracting("productStore")
+                        .contains("PB_CU", "PB_GS25", "PB_EMART24", "PB_SEVEN_ELEVEN",
+                                "EVENT_CU", "EVENT_GS25", "EVENT_EMART24", "EVENT_SEVEN_ELEVEN"),
+                () -> assertThat(result).extracting("isSubscribed")
+                        .containsOnly(true));
+    }
+
+    @DisplayName("편의점 푸시 알림을 구독 취소합니다.")
+    @Test
+    void subscribePushProductStores() {
+        Member member =  Member.builder()
+                .email("sample@gmail.com")
+                .OAuthType(OAuthType.APPLE)
+                .oAuthId("apple-sample@gmail.com")
+                .refreshToken("refreshToken")
+                .role(Role.ROLE_USER).build();
+        memberRepository.save(member);
+        pushProductStoreService.createPushProductStores(member);
+        AuthUserDetails authUserDetails = getAuthentication(member);
+
+        PushProductStoreRequestDto requestDto = PushProductStoreRequestDto.builder()
+                .pushProductStores(List.of("EVENT_CU", "PB_CU"))
+                .build();
+
+        pushProductStoreService.unsubscribePushProductStores(authUserDetails, requestDto);
+        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(authUserDetails);
+
+        assertAll(
+                () -> assertThat(result).filteredOn(PushProductStoreResponseDto::getProductStore, "PB_CU")
+                        .filteredOn(PushProductStoreResponseDto::getIsSubscribed, false),
+                () -> assertThat(result).filteredOn(PushProductStoreResponseDto::getProductStore,"EVENT_CU")
+                        .filteredOn(PushProductStoreResponseDto::getIsSubscribed, false));
+    }
+
+    // CustomUserDetails로 Member 객체를 매핑하기 때문에 필요 - 이후 수정
+    private AuthUserDetails getAuthentication(Member member){
+        SecurityContext context = SecurityContextHolder.getContext();
+        AuthUserDetails authUserDetails = new AuthUserDetails(member);
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                authUserDetails,
+                "",
+                authUserDetails.getAuthorities()));
+        return authUserDetails;
+    }
+}

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/member/Member.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/member/Member.java
@@ -1,10 +1,10 @@
 package com.pyonsnalcolor.member;
 
-import com.pyonsnalcolor.alarm.PushProductStore;
-import com.pyonsnalcolor.alarm.PushKeyword;
-import com.pyonsnalcolor.alarm.PushRecord;
+import com.pyonsnalcolor.push.PushProductStore;
+import com.pyonsnalcolor.push.PushKeyword;
 import com.pyonsnalcolor.member.enumtype.OAuthType;
 import com.pyonsnalcolor.member.enumtype.Role;
+import com.pyonsnalcolor.push.PushRecord;
 import lombok.*;
 
 import javax.persistence.*;
@@ -34,6 +34,7 @@ public class Member {
     @Pattern(regexp="^[0-9a-zA-Zㄱ-ㅎ가-힣 ]{1,15}")
     private String nickname;
 
+    @Column(length = 500)
     private String refreshToken;
 
     private String deviceToken; // FCM용 디바이스 토큰

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/PushKeyword.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/PushKeyword.java
@@ -1,32 +1,25 @@
-package com.pyonsnalcolor.alarm;
+package com.pyonsnalcolor.push;
 
 import com.pyonsnalcolor.member.Member;
-import com.pyonsnalcolor.product.enumtype.StoreType;
 import lombok.*;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
+import javax.validation.constraints.Pattern;
 
 @Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "push_record")
-public class PushRecord {
+@Table(name = "push_keyword")
+public class PushKeyword {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "push_record_id")
+    @Column(name = "push_keyword_id")
     private Long id;
 
-    private String title;
-
-    private String body;
-
-    private StoreType storeType;
-
-    @Column(name = "created_time")
-    private LocalDateTime createdTime;
+    @Pattern(regexp="^[0-9a-zA-Zㄱ-ㅎ가-힣]{1,10}")
+    private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/PushProductStore.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/PushProductStore.java
@@ -1,4 +1,4 @@
-package com.pyonsnalcolor.alarm;
+package com.pyonsnalcolor.push;
 
 import com.pyonsnalcolor.product.enumtype.ProductStoreType;
 import com.pyonsnalcolor.member.Member;

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/PushProductStore.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/PushProductStore.java
@@ -34,4 +34,8 @@ public class PushProductStore {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void updateSubscribedStatus(boolean updatedStatus) {
+        isSubscribed = updatedStatus;
+    }
 }

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/PushRecord.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/PushRecord.java
@@ -1,25 +1,32 @@
-package com.pyonsnalcolor.alarm;
+package com.pyonsnalcolor.push;
 
 import com.pyonsnalcolor.member.Member;
+import com.pyonsnalcolor.product.enumtype.StoreType;
 import lombok.*;
 
 import javax.persistence.*;
-import javax.validation.constraints.Pattern;
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "push_keyword")
-public class PushKeyword {
+@Table(name = "push_record")
+public class PushRecord {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "push_keyword_id")
+    @Column(name = "push_record_id")
     private Long id;
 
-    @Pattern(regexp="^[0-9a-zA-Zㄱ-ㅎ가-힣]{1,10}")
-    private String name;
+    private String title;
+
+    private String body;
+
+    private StoreType storeType;
+
+    @Column(name = "created_time")
+    private LocalDateTime createdTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/repository/PushKeywordRepository.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/repository/PushKeywordRepository.java
@@ -1,6 +1,6 @@
-package com.pyonsnalcolor.alarm.repository;
+package com.pyonsnalcolor.push.repository;
 
-import com.pyonsnalcolor.alarm.PushKeyword;
+import com.pyonsnalcolor.push.PushKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/repository/PushProductStoreRepository.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/repository/PushProductStoreRepository.java
@@ -1,6 +1,6 @@
-package com.pyonsnalcolor.alarm.repository;
+package com.pyonsnalcolor.push.repository;
 
-import com.pyonsnalcolor.alarm.PushProductStore;
+import com.pyonsnalcolor.push.PushProductStore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/repository/PushRecordRepository.java
+++ b/pyonsnalcolor-domain/src/main/java/com/pyonsnalcolor/push/repository/PushRecordRepository.java
@@ -1,6 +1,6 @@
-package com.pyonsnalcolor.alarm.repository;
+package com.pyonsnalcolor.push.repository;
 
-import com.pyonsnalcolor.alarm.PushRecord;
+import com.pyonsnalcolor.push.PushRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 


### PR DESCRIPTION
### 구현 사항
- 푸시 구독 목록 조회/저장/삭제 기능 구현
  - 처음 회원가입 시, 구독 목록 모두 구독 신청 상태(isSubscribed=true) 테스트
- 푸시 키워드 조회/저장/삭제 기능 구현
  - 키워드 3개 제한, 유효성 검사 테스트
- 푸시 알림은 alarm -> push로 패키지명 변경

### 참고 사항
- 이후에 (배치 에러 시)디스코드 알림 등 다른 알림이랑 구분하기 위해서 
- 푸시 알림 관련 이름은 push로 통일했습니다 (alarm -> push)

**swagger에서 https 연결 안되는 이슈**
- (자동으로 http로 스키마 정해져서 http로 서버 올릴때는 문제없었는데 https로 올린 서버에서는 연결X)
- => https로 요청 보내려면 다음 설정 필요 
```
@OpenAPIDefinition(servers = {@server(url = "/"))
@SpringBootApplication
```
- https://github.com/springdoc/springdoc-openapi/issues/726 참고