### PR TITLE
feat: 배치 예외 처리 AOP 구현, 예외 발생 시 Slack에 알림 전송

### DIFF
--- a/pyonsnalcolor-api/build.gradle
+++ b/pyonsnalcolor-api/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch:2.7.12'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.7'
     testImplementation 'org.springframework.batch:spring-batch-test:4.3.8'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation("net.gpedro.integrations.slack:slack-webhook:1.4.0")
 
     // FCM
     implementation 'com.google.firebase:firebase-admin:9.2.0'

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/aop/BatchExceptionAspect.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/aop/BatchExceptionAspect.java
@@ -1,0 +1,74 @@
+package com.pyonsnalcolor.aop;
+
+import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
+import lombok.extern.slf4j.Slf4j;
+import net.gpedro.integrations.slack.SlackApi;
+import net.gpedro.integrations.slack.SlackAttachment;
+import net.gpedro.integrations.slack.SlackField;
+import net.gpedro.integrations.slack.SlackMessage;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Aspect
+@Component
+public class BatchExceptionAspect {
+
+    private static final String SLACK_URL = "https://hooks.slack.com/services/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";
+
+    @Pointcut("execution(* com.pyonsnalcolor.batch.service..*(..))")
+    private void allBatchService() {}
+
+    @AfterThrowing(value = "allBatchService()", throwing = "exception")
+    public void catchBatchException(JoinPoint joinPoint, PyonsnalcolorBatchException exception) {
+        log.error("[{}] 배치 실행 중 {}에서 예외가 발생하였습니다.", exception.getClass().getSimpleName(),
+                joinPoint.getTarget().getClass().getSimpleName());
+        log.error("[custom exception] {} {} ", exception.getErrorCode().name(), exception.getErrorCode().getMessage());
+        log.error("[origin exception] {} {}", exception.getOriginException().getClass().getSimpleName(),
+                exception.getOriginException().getMessage());
+
+        sendErrorSlackAlarm(joinPoint, exception);
+    }
+
+    private void sendErrorSlackAlarm(JoinPoint joinPoint, PyonsnalcolorBatchException exception) {
+        SlackApi api = new SlackApi(SLACK_URL);
+
+        SlackMessage errorSlackMessage = createErrorSlackMessage(joinPoint, exception);
+        api.call(errorSlackMessage);
+    }
+
+    private SlackMessage createErrorSlackMessage(JoinPoint joinPoint, PyonsnalcolorBatchException exception) {
+        SlackMessage slackMessage = new SlackMessage();
+        slackMessage.setText("Batch Error Occur");
+        slackMessage.setIcon(":ghost:");
+        slackMessage.setUsername("pyonsnalcolor");
+
+        SlackAttachment slackAttachment = new SlackAttachment();
+        slackAttachment.setFallback("Batch Error");
+        slackAttachment.setTitle("배치 실행중 예외가 발생하였습니다.");
+        slackAttachment.setColor("#ffff00");
+        slackAttachment.setText(Arrays.toString(exception.getStackTrace()));
+        slackAttachment.setFields (
+                List.of(
+                        new SlackField().setTitle("Occurred Time").setValue(LocalDateTime.now().toString()),
+                        new SlackField().setTitle("Occurred Class")
+                                .setValue(joinPoint.getTarget().getClass().getSimpleName()),
+                        new SlackField().setTitle("Custom Message").setValue(exception.getErrorCode().getMessage()),
+                        new SlackField().setTitle("Origin Exception")
+                                .setValue(exception.getOriginException().getClass().getSimpleName()),
+                        new SlackField().setTitle("Origin Exception Message")
+                                .setValue(exception.getOriginException().getMessage())
+                )
+        );
+        slackMessage.setAttachments(Collections.singletonList(slackAttachment));
+        return slackMessage;
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/aop/BatchExceptionAspect.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/aop/BatchExceptionAspect.java
@@ -10,6 +10,7 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -22,7 +23,8 @@ import java.util.List;
 @Component
 public class BatchExceptionAspect {
 
-    private static final String SLACK_URL = "https://hooks.slack.com/services/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";
+    @Value("${slack.url}")
+    private String SLACK_URL;
 
     @Pointcut("execution(* com.pyonsnalcolor.batch.service..*(..))")
     private void allBatchService() {}
@@ -48,7 +50,7 @@ public class BatchExceptionAspect {
     private SlackMessage createErrorSlackMessage(JoinPoint joinPoint, PyonsnalcolorBatchException exception) {
         SlackMessage slackMessage = new SlackMessage();
         slackMessage.setText("Batch Error Occur");
-        slackMessage.setIcon(":ghost:");
+        slackMessage.setIcon(":beverage_box:");
         slackMessage.setUsername("pyonsnalcolor");
 
         SlackAttachment slackAttachment = new SlackAttachment();

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuDescriptionBatch.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuDescriptionBatch.java
@@ -1,5 +1,6 @@
 package com.pyonsnalcolor.batch.service.cu;
 
+import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -8,6 +9,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+
+import static com.pyonsnalcolor.exception.model.BatchErrorCode.*;
+import static com.pyonsnalcolor.exception.model.BatchErrorCode.BATCH_UNAVAILABLE;
 
 public interface CuDescriptionBatch {
 
@@ -28,11 +32,13 @@ public interface CuDescriptionBatch {
             Elements elements = doc.select("ul.prodExplain li");
             return elements.text();
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("URL 주소가 유효하지 않습니다.");
+            throw new PyonsnalcolorBatchException(INVALID_ACCESS, e);
         } catch (SocketTimeoutException e) {
-            throw new SocketTimeoutException("연결 시간이 초과하였습니다.");
+            throw new PyonsnalcolorBatchException(TIME_OUT, e);
         } catch (IOException e) {
-            throw new IOException("연결에 실패하였습니다.");
+            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
+        } catch (Exception e) {
+            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
         }
     }
 

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuDescriptionBatch.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuDescriptionBatch.java
@@ -18,7 +18,7 @@ public interface CuDescriptionBatch {
     String CU_DESCRIPTION_PAGE_URL = "https://cu.bgfretail.com/product/view.do";
     int TIMEOUT = 15000;
 
-    default String getDescription(Element element, String productType) throws Exception {
+    default String getDescription(Element element, String productType) {
         String productCode = getProductCode(element);
 
         try {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
@@ -87,18 +87,7 @@ public class CuEventBatchService extends EventBatchService implements CuDescript
         String eventTypeTag = element.select("div.badge").first().text();
         EventType eventType = getCuEventType(eventTypeTag);
 
-        String description = null;
-        try {
-            description = getDescription(element, "event");
-        } catch (IllegalArgumentException e) {
-            throw new PyonsnalcolorBatchException(INVALID_ACCESS, e);
-        } catch (SocketTimeoutException e) {
-            throw new PyonsnalcolorBatchException(TIME_OUT, e);
-        } catch (IOException e) {
-            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
-        } catch (Exception e) {
-            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
-        }
+        String description = getDescription(element, "event");
         Category category = Category.matchCategoryByProductName(name);
         Tag tag = Tag.findTag(name);
 

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
@@ -1,6 +1,8 @@
 package com.pyonsnalcolor.batch.service.cu;
 
 import com.pyonsnalcolor.batch.service.PbBatchService;
+import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
+import com.pyonsnalcolor.exception.model.BatchErrorCode;
 import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.enumtype.Category;
 import com.pyonsnalcolor.product.enumtype.StoreType;
@@ -14,6 +16,8 @@ import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,13 +41,18 @@ public class CuPbBatchService extends PbBatchService implements CuDescriptionBat
     }
 
     @Override
-    protected List<BasePbProduct> getAllProducts(){
+    protected List<BasePbProduct> getAllProducts() {
         try {
             return getProductsByCategoryAll();
+        } catch (IllegalArgumentException e) {
+            throw new PyonsnalcolorBatchException(BatchErrorCode.INVALID_ACCESS, e);
+        } catch (SocketTimeoutException e) {
+            throw new PyonsnalcolorBatchException(BatchErrorCode.TIME_OUT, e);
+        } catch (IOException e) {
+            throw new PyonsnalcolorBatchException(BatchErrorCode.IO_EXCEPTION, e);
         } catch (Exception e) {
-            log.error("CU PB 상품 조회하는 데 실패했습니다.", e);
+            throw new PyonsnalcolorBatchException(BatchErrorCode.BATCH_UNAVAILABLE, e);
         }
-        return null; // 이후에 에러 처리 관련 수정 - getAllProducts() 호출하는 쪽에 throw
     }
 
     private List<BasePbProduct> getProductsByCategoryAll() throws Exception {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
@@ -91,12 +91,7 @@ public class CuPbBatchService extends PbBatchService implements CuDescriptionBat
             image = SCHEMA + image;
         }
         String price = element.select("div.price > strong").first().text();
-        String description = null;
-        try {
-            description = getDescription(element, "product");
-        } catch (Exception e) {
-            log.error("CU PB 상품의 상세 정보를 조회할 수 없습니다.", e);
-        }
+        String description = getDescription(element, "product");
         Category category = Category.matchCategoryByProductName(name);
         Tag tag = Tag.findTag(name);
 

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24EventBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24EventBatchService.java
@@ -64,20 +64,13 @@ public class Emart24EventBatchService extends EventBatchService {
             String giftImage = parseGiftImage(productElement);
             EventType eventType = parseEventType(productElement);
             String name = parseName(productElement);
-            String price = convertToNum(productElement.getElementsByClass("price").get(0).text());
+            String price = productElement.getElementsByClass("price").get(0).text().split(" ")[0];
             String originPrice = parseOriginPrice(productElement);
             String image = productElement.getElementsByTag("img").attr("src");
 
             results.add(convertToBaseEventProduct(image, name, price, originPrice, giftImage, eventType));
         }
         return results;
-    }
-
-    private String convertToNum(String price) {
-        String priceInfo = price.split(" ")[0];
-        String result = priceInfo.replace(",", "");
-
-        return result;
     }
 
     private String parseGiftImage(Element productElement) {
@@ -97,7 +90,8 @@ public class Emart24EventBatchService extends EventBatchService {
             originPrice = originPriceElement.get(0).text();
         }
 
-        return originPrice;
+        String parsedOriginPrice = originPrice.split(" ")[0];
+        return parsedOriginPrice;
     }
 
     private String parseName(Element productElement) {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PbBatchService.java
@@ -62,19 +62,12 @@ public class Emart24PbBatchService extends PbBatchService {
             Elements itemTitle = productElement.getElementsByClass("itemtitle");
             Element element = itemTitle.get(0);
             String name = element.getElementsByTag("a").get(0).text();
-            String price = convertToNum(productElement.getElementsByClass("price").get(0).text());
+            String price = productElement.getElementsByClass("price").get(0).text().split(" ")[0];
             String image = productElement.getElementsByTag("img").attr("src");
 
             results.add(convertToBasePbProduct(image, name, price));
         }
         return results;
-    }
-
-    private String convertToNum(String price) {
-        String priceInfo = price.split(" ")[0];
-        String result = priceInfo.replace(",", "");
-
-        return result;
     }
 
     private BasePbProduct convertToBasePbProduct(String image, String name, String price) {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25EventBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25EventBatchService.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,7 +101,9 @@ public class GS25EventBatchService extends EventBatchService {
         Map<String, Object> productMap = objectMapper.convertValue(product, Map.class);
         String image = (String) productMap.get("attFileNm");
         String name = (String) productMap.get("goodsNm");
-        String price = Double.toString((Double) productMap.get("price"));
+        String price = Double.toString((Double) productMap.get("price")).split("\\.")[0];
+        int priceInt = Integer.parseInt(price);
+        String formattedPrice = NumberFormat.getInstance().format(priceInt);
         String eventType = (String) ((Map) productMap.get("eventTypeSp")).get("code");
         String giftImage = (String) productMap.get("giftAttFileNm");
         Category category = Category.matchCategoryByProductName(name);
@@ -114,7 +117,7 @@ public class GS25EventBatchService extends EventBatchService {
                 .id(generateId())
                 .giftImage(giftImage)
                 .image(image)
-                .price(price)
+                .price(formattedPrice)
                 .name(name)
                 .category(category)
                 .tag(tag)

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25PbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25PbBatchService.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -91,14 +92,17 @@ public class GS25PbBatchService extends PbBatchService {
         Map<String, Object> productMap = objectMapper.convertValue(product, Map.class);
         String image = (String) productMap.get("attFileNm");
         String name = (String) productMap.get("goodsNm");
-        String price = Double.toString((Double) productMap.get("price"));
+        String price = Double.toString((Double) productMap.get("price")).split("\\.")[0];;
+        int priceInt = Integer.parseInt(price);
+        String formattedPrice = NumberFormat.getInstance().format(priceInt);
+
         Category category = Category.matchCategoryByProductName(name);
         Tag tag = Tag.findTag(name);
 
         BasePbProduct basePbProduct = BasePbProduct.builder()
                 .id(generateId())
                 .name(name)
-                .price(price)
+                .price(formattedPrice)
                 .storeType(StoreType.GS25)
                 .updatedTime(LocalDateTime.now())
                 .image(image)

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
@@ -1,6 +1,7 @@
 package com.pyonsnalcolor.batch.service.seven;
 
 import com.pyonsnalcolor.batch.service.EventBatchService;
+import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
 import com.pyonsnalcolor.product.repository.EventProductRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -11,10 +12,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+
+import static com.pyonsnalcolor.exception.model.BatchErrorCode.*;
+import static com.pyonsnalcolor.exception.model.BatchErrorCode.BATCH_UNAVAILABLE;
 
 @Service("SevenEvent")
 @Slf4j
@@ -42,10 +47,15 @@ public class SevenEventBatchService extends EventBatchService {
     private List<BaseEventProduct> getProductsAllTab(SevenEventTab sevenEventTab) {
         try {
             return getProductsByTab(sevenEventTab);
-        } catch (IOException ioException) {
-            log.error("세븐일레븐 이벤트 {}탭의 상품 조회하는 데 실패했습니다.", sevenEventTab, ioException);
+        } catch (IllegalArgumentException e) {
+            throw new PyonsnalcolorBatchException(INVALID_ACCESS, e);
+        } catch (SocketTimeoutException e) {
+            throw new PyonsnalcolorBatchException(TIME_OUT, e);
+        } catch (IOException e) {
+            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
+        } catch (Exception e) {
+            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
         }
-        return null;
     }
 
     public List<BaseEventProduct> getProductsByTab(SevenEventTab sevenEventTab) throws IOException {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
@@ -1,5 +1,7 @@
 package com.pyonsnalcolor.batch.service.seven;
 
+import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
+import com.pyonsnalcolor.exception.model.BatchErrorCode;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
 import com.pyonsnalcolor.product.enumtype.Category;
 import com.pyonsnalcolor.product.enumtype.EventType;
@@ -13,12 +15,15 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static com.pyonsnalcolor.exception.model.BatchErrorCode.*;
 import static com.pyonsnalcolor.product.entity.UUIDGenerator.generateId;
 
 @Slf4j
@@ -137,9 +142,14 @@ public enum SevenEventTab {
             Document doc = Jsoup.connect(originPriceUrl).timeout(TIMEOUT).get();
             Elements elements = doc.select("div.cont_top span.product_price del");
             return elements.text().replace(" >", "");
+        } catch (IllegalArgumentException e) {
+            throw new PyonsnalcolorBatchException(INVALID_ACCESS, e);
+        } catch (SocketTimeoutException e) {
+            throw new PyonsnalcolorBatchException(TIME_OUT, e);
+        } catch (IOException e) {
+            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
         } catch (Exception e) {
-            log.error("세븐일레븐 할인 상품의 상세 페이지로 이동할 수 없습니다.", e);
+            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
         }
-        return null;
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
@@ -1,6 +1,8 @@
 package com.pyonsnalcolor.batch.service.seven;
 
 import com.pyonsnalcolor.batch.service.PbBatchService;
+import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
+import com.pyonsnalcolor.exception.model.BatchErrorCode;
 import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.enumtype.Category;
 import com.pyonsnalcolor.product.enumtype.StoreType;
@@ -15,11 +17,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.pyonsnalcolor.exception.model.BatchErrorCode.*;
+import static com.pyonsnalcolor.exception.model.BatchErrorCode.BATCH_UNAVAILABLE;
 import static com.pyonsnalcolor.product.entity.UUIDGenerator.generateId;
 
 @Service("SevenPb")
@@ -37,13 +42,18 @@ public class SevenPbBatchService extends PbBatchService {
     }
 
     @Override
-    protected List<BasePbProduct> getAllProducts() {
+    protected List<BasePbProduct> getAllProducts(){
         try {
             return getProducts();
+        } catch (IllegalArgumentException e) {
+            throw new PyonsnalcolorBatchException(INVALID_ACCESS, e);
+        } catch (SocketTimeoutException e) {
+            throw new PyonsnalcolorBatchException(TIME_OUT, e);
+        } catch (IOException e) {
+            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
         } catch (Exception e) {
-            log.error("세븐일레븐 PB 상품 조회하는 데 실패했습니다.", e);
+            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
         }
-        return null; // 이후에 에러 처리 관련 수정 - getAllProducts() 호출하는 쪽에 throw
     }
 
     private List<BasePbProduct> getProducts() throws IOException {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/PyonsnalcolorBatchException.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/PyonsnalcolorBatchException.java
@@ -1,0 +1,15 @@
+package com.pyonsnalcolor.exception;
+
+import com.pyonsnalcolor.exception.model.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class PyonsnalcolorBatchException extends PyonsnalcolorException {
+
+    private final Exception originException;
+
+    public PyonsnalcolorBatchException(ErrorCode errorCode, Exception originException) {
+        super(errorCode);
+        this.originException = originException;
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/model/BatchErrorCode.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/model/BatchErrorCode.java
@@ -1,0 +1,21 @@
+package com.pyonsnalcolor.exception.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Getter
+@RequiredArgsConstructor
+public enum BatchErrorCode implements ErrorCode{
+
+    INVALID_ACCESS(BAD_REQUEST, "해당 URL이 유효하지 않습니다."),
+    TIME_OUT(BAD_REQUEST, "연결 시간이 초과되었습니다."),
+    IO_EXCEPTION(BAD_REQUEST, "페이지에 접근할 수 없습니다."),
+    BATCH_UNAVAILABLE(BAD_REQUEST, "배치를 실행할 수 없습니다. 확인이 필요합니다."),
+    INVALID_PRODUCT_TYPE(BAD_REQUEST, "상품 정보가 기존 형식과 다릅니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/pyonsnalcolor-api/src/main/resources/application.yml
+++ b/pyonsnalcolor-api/src/main/resources/application.yml
@@ -55,3 +55,5 @@ springdoc:
 fcm:
   key: ${FCM_KEY}
   scope: https://www.googleapis.com/auth/firebase.messaging
+slack:
+  url: ${SLACK_URL}


### PR DESCRIPTION
### 구현 사항
- 배치 예외 처리 AOP 구현
- 예외 발생 시, Slack에 알림 전송
- #60 

### 참고 사항
- #4 
- PyonsnalcolorBatchException으로 묶어서 AOP에서 예외 처리
- (다른 기능에서의 IllegalException은 ExceptionHandler로 에러 응답을 클라에게 반환하고,
  배치에서의 IllegalException은 따로 알림등의 처리를 해주기 위해서)
- 클라 응답용 예외 처리 => _@ RestControllerAdvice_
- 배치 관련 부가 기능 => _@ Aspect_ 으로 다음 부가 기능들 일괄적으로 관리할 예정!
  - [X] 예외 발생 시 슬랙 알림
  - [ ] 새 상품 업데이트 시 슬랙 알림
  - [ ] 시간 측정..?

**슬랙에 예외 상황 알림 전송 테스트** [참고](https://github.com/gpedro/slack-webhook/tree/master)


![image](https://github.com/YAPP-Github/pyonsnalcolor-server/assets/77563814/ac434054-61d7-4bec-8e38-15269e88d058)

**log 출력**

![image](https://github.com/YAPP-Github/pyonsnalcolor-server/assets/77563814/54afdbfb-5e66-42f9-8d3a-80ccae43771f)