### PR TITLE
Feature/refactor login : 로그인 기능 리팩토링

### DIFF
--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/AuthMemberId.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/AuthMemberId.java
@@ -1,0 +1,11 @@
+package com.pyonsnalcolor.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMemberId {
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/AuthParameterResolver.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/AuthParameterResolver.java
@@ -1,0 +1,34 @@
+package com.pyonsnalcolor.auth;
+
+import com.pyonsnalcolor.auth.security.AuthUserDetails;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+@Component
+public class AuthParameterResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthMemberId.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws Exception {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        AuthUserDetails principal = (AuthUserDetails) authentication.getPrincipal();
+        return principal.getMember().getId();
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/AuthController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/AuthController.java
@@ -1,11 +1,6 @@
 package com.pyonsnalcolor.auth.controller;
 
-import com.pyonsnalcolor.auth.dto.LoginResponseDto;
-import com.pyonsnalcolor.auth.dto.LoginRequestDto;
-import com.pyonsnalcolor.auth.dto.TokenDto;
-import com.pyonsnalcolor.auth.enumtype.OAuthType;
-import com.pyonsnalcolor.auth.oauth.apple.AppleOauthService;
-import com.pyonsnalcolor.auth.oauth.kakao.KakaoOauthService;
+import com.pyonsnalcolor.auth.dto.*;
 import com.pyonsnalcolor.auth.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,29 +19,25 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final MemberService memberService;
-    private final KakaoOauthService kakaoOauthService;
-    private final AppleOauthService appleOauthService;
 
-    @Operation(summary = "Kakao 인증", description = "Kakao Access Token으로 이메일 정보를 얻어 회원가입/재로그인 합니다.")
-    @Parameter(name = "loginRequestDto", description = "Kakao에서 받은 Access Token")
-    @PostMapping("/kakao")
-    public ResponseEntity<LoginResponseDto> loginWithKakao(
+    @Operation(summary = "OAuth 인증", description = "Token으로 이메일 정보를 얻어 회원가입/재로그인합니다.")
+    @Parameter(name = "loginRequestDto", description = "OAuth Token과 OAuth 타입(Apple, Kakao)")
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> login(
             @RequestBody LoginRequestDto loginRequestDto
     ) {
-        String email = kakaoOauthService.getEmail(loginRequestDto);
-        LoginResponseDto loginResponseDto = memberService.oAuthLogin(OAuthType.KAKAO, email);
+        LoginResponseDto loginResponseDto = memberService.oAuthLogin(loginRequestDto);
         return new ResponseEntity(loginResponseDto, HttpStatus.OK);
     }
 
-    @Operation(summary = "Apple 인증", description = "Apple Identity Token으로 이메일 정보를 얻어 회원가입/재로그인 합니다.")
-    @Parameter(name = "loginRequestDto", description = "Apple에서 받은 Identity Token")
-    @PostMapping("/apple")
-    public ResponseEntity<LoginResponseDto> loginWithApple(
+    @Operation(summary = "회원가입 여부 조회", description = "이미 가입된 회원인지 조회합니다.")
+    @Parameter(name = "loginRequestDto", description = "OAuth Token과 OAuth 타입")
+    @PostMapping("/status")
+    public ResponseEntity<JoinStatusResponseDto> getJoinStatus(
             @RequestBody LoginRequestDto loginRequestDto
     ) {
-        String email = appleOauthService.getEmail(loginRequestDto);
-        LoginResponseDto loginResponseDto = memberService.oAuthLogin(OAuthType.APPLE, email);
-        return new ResponseEntity(loginResponseDto, HttpStatus.OK);
+        JoinStatusResponseDto joinStatusResponseDto = memberService.getJoinStatus(loginRequestDto);
+        return new ResponseEntity(joinStatusResponseDto, HttpStatus.OK);
     }
 
     @Operation(summary = "JWT 토큰 재발급", description = "Access Token의 만료 기한이 지났을 때, 재로그인합니다.")
@@ -57,21 +48,5 @@ public class AuthController {
     ) {
         LoginResponseDto tokenResponseDto = memberService.reissueAccessToken(tokenRequestDto);
         return new ResponseEntity(tokenResponseDto, HttpStatus.OK);
-    }
-
-    @Operation(summary = "테스트 인증", description = "이메일만으로 로그인하기")
-    @Parameter(name = "loginRequestDto", description = "예시 이메일")
-    @PostMapping("/test/login")
-    public ResponseEntity<LoginResponseDto> testLogin(
-            @RequestBody LoginRequestDto loginRequestDto
-    ) {
-        String email = loginRequestDto.getToken();
-        LoginResponseDto loginResponseDto = memberService.oAuthLogin(OAuthType.APPLE, email);
-        return new ResponseEntity(loginResponseDto, HttpStatus.OK);
-    }
-
-    @GetMapping("/test")
-    public ResponseEntity<String> test() {
-        return new ResponseEntity("Welcome to Pyonsnal Color", HttpStatus.OK);
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/AuthController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.pyonsnalcolor.auth.controller;
 
+import com.pyonsnalcolor.auth.MemberRepository;
 import com.pyonsnalcolor.auth.dto.*;
 import com.pyonsnalcolor.auth.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
 
     @Operation(summary = "OAuth 인증", description = "Token으로 이메일 정보를 얻어 회원가입/재로그인합니다.")
     @Parameter(name = "loginRequestDto", description = "OAuth Token과 OAuth 타입(Apple, Kakao)")

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/MemberController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/controller/MemberController.java
@@ -1,9 +1,9 @@
 package com.pyonsnalcolor.auth.controller;
 
+import com.pyonsnalcolor.auth.AuthMemberId;
 import com.pyonsnalcolor.auth.dto.MemberInfoResponseDto;
 import com.pyonsnalcolor.auth.dto.NicknameRequestDto;
 import com.pyonsnalcolor.auth.dto.TokenDto;
-import com.pyonsnalcolor.auth.AuthUserDetails;
 import com.pyonsnalcolor.auth.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,8 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -36,10 +34,9 @@ public class MemberController {
     @Operation(summary = "사용자 정보 조회", description = "사용자의 정보를 조회합니다.")
     @GetMapping("/info")
     public ResponseEntity<MemberInfoResponseDto> getMemberInfo(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal AuthUserDetails authUserDetails
+            @Parameter(hidden = true) @AuthMemberId Long memberId
     ) {
-        MemberInfoResponseDto memberInfoResponseDto = memberService.getMemberInfo(authUserDetails);
+        MemberInfoResponseDto memberInfoResponseDto = memberService.getMemberInfo(memberId);
         return new ResponseEntity(memberInfoResponseDto, HttpStatus.OK);
     }
 
@@ -48,19 +45,18 @@ public class MemberController {
     @PatchMapping("/nickname")
     public ResponseEntity<TokenDto> updateNickname(
             @RequestBody @Valid NicknameRequestDto nicknameRequestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal AuthUserDetails authUserDetails
+            @Parameter(hidden = true) @AuthMemberId Long memberId
     ) {
-        memberService.updateNickname(authUserDetails, nicknameRequestDto);
+        memberService.updateNickname(memberId, nicknameRequestDto);
         return new ResponseEntity(HttpStatus.OK);
     }
 
     @Operation(summary = "회원 탈퇴", description = "사용자 정보를 삭제합니다.")
     @DeleteMapping("/withdraw")
     public ResponseEntity<TokenDto> withdraw(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal AuthUserDetails authUserDetails
+            @Parameter(hidden = true) @AuthMemberId Long memberId
     ) {
-        memberService.withdraw(authUserDetails);
+        memberService.withdraw(memberId);
         return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/JoinStatusResponseDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/JoinStatusResponseDto.java
@@ -1,0 +1,21 @@
+package com.pyonsnalcolor.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Schema(description = "회원가입 여부 Response DTO")
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class JoinStatusResponseDto {
+
+    @Schema(description = "회원가입 여부")
+    @NotBlank
+    private Boolean isJoined;
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/LoginRequestDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/dto/LoginRequestDto.java
@@ -1,6 +1,8 @@
 package com.pyonsnalcolor.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,10 +10,16 @@ import javax.validation.constraints.NotBlank;
 
 @Schema(description = "OAuth 로그인용 Request DTO")
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class LoginRequestDto {
 
     @Schema(description = "OAuth 로그인 후 받은 토큰")
-    @NotBlank
+    @NotBlank(message = "OAuth 타입별로 로그인 후 받은 토큰을 입력해야 합니다.")
     private String token;
+
+    @Schema(description = "OAuth 타입")
+    @NotBlank(message = "OAuth 타입을 입력해야 합니다.")
+    private String oauthType;
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/oauth/OAuthClient.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/oauth/OAuthClient.java
@@ -1,0 +1,11 @@
+package com.pyonsnalcolor.auth.oauth;
+
+import com.pyonsnalcolor.auth.dto.LoginRequestDto;
+import com.pyonsnalcolor.auth.enumtype.OAuthType;
+
+public interface OAuthClient {
+
+    OAuthType oAuthType();
+
+    String getEmail(LoginRequestDto loginRequestDto);
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/oauth/OAuthLoginService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/oauth/OAuthLoginService.java
@@ -1,0 +1,39 @@
+package com.pyonsnalcolor.auth.oauth;
+
+import com.pyonsnalcolor.auth.dto.LoginRequestDto;
+import com.pyonsnalcolor.auth.enumtype.OAuthType;
+import com.pyonsnalcolor.exception.PyonsnalcolorAuthException;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.pyonsnalcolor.exception.model.AuthErrorCode.OAUTH_UNSUPPORTED;
+
+@Component
+public class OAuthLoginService {
+
+    private final List<OAuthClient> oAuthClients;
+
+    private OAuthLoginService(List<OAuthClient> oAuthClients) {
+        this.oAuthClients = oAuthClients;
+    }
+
+    public OAuthClient getOAuthLoginClient(LoginRequestDto loginRequestDto) {
+        String oAuthTypeString = loginRequestDto.getOauthType().toUpperCase();
+        OAuthType oAuthType = getOAuthType(oAuthTypeString);
+
+        return this.oAuthClients.stream()
+                .filter(o-> o.oAuthType() == oAuthType)
+                .findFirst()
+                .orElseThrow(() -> new PyonsnalcolorAuthException(OAUTH_UNSUPPORTED));
+    }
+
+    private static OAuthType getOAuthType(String oAuthTypeString) {
+
+        return Arrays.stream(OAuthType.values())
+                .filter(o -> o.name().equals(oAuthTypeString))
+                .findFirst()
+                .orElseThrow(() -> new PyonsnalcolorAuthException(OAUTH_UNSUPPORTED));
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/oauth/kakao/KakaoOauthClient.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/oauth/kakao/KakaoOauthClient.java
@@ -1,7 +1,11 @@
 package com.pyonsnalcolor.auth.oauth.kakao;
 
 import com.pyonsnalcolor.auth.dto.LoginRequestDto;
+import com.pyonsnalcolor.auth.enumtype.OAuthType;
+import com.pyonsnalcolor.auth.oauth.OAuthClient;
 import com.pyonsnalcolor.auth.oauth.kakao.dto.KakaoUserInfoDto;
+import com.pyonsnalcolor.exception.PyonsnalcolorAuthException;
+import com.pyonsnalcolor.exception.model.AuthErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +20,7 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 @Service
 @PropertySource("classpath:application-oauth.yml")
-public class KakaoOauthService {
+public class KakaoOauthClient implements OAuthClient {
 
     @Value("${jwt.bearer.header}")
     private String bearerHeader;
@@ -30,9 +34,19 @@ public class KakaoOauthService {
     @Autowired
     private RestTemplate restTemplate;
 
+    @Override
+    public OAuthType oAuthType() {
+        return OAuthType.KAKAO;
+    }
+
+    @Override
     public String getEmail(LoginRequestDto loginRequestDto) {
         String accessToken = loginRequestDto.getToken();
-        return getKakaoUserInfo(accessToken).getEmail();
+        String email =  getKakaoUserInfo(accessToken).getEmail();
+        if (email == null) {
+            throw new PyonsnalcolorAuthException(AuthErrorCode.EMAIL_UNAUTHORIZED);
+        }
+        return email;
     }
 
     private KakaoUserInfoDto getKakaoUserInfo (String accessToken) {

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/security/AuthUserDetails.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/security/AuthUserDetails.java
@@ -1,6 +1,7 @@
-package com.pyonsnalcolor.auth;
+package com.pyonsnalcolor.auth.security;
 
 
+import com.pyonsnalcolor.auth.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/security/AuthUserDetailsService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/security/AuthUserDetailsService.java
@@ -1,5 +1,7 @@
-package com.pyonsnalcolor.auth;
+package com.pyonsnalcolor.auth.security;
 
+import com.pyonsnalcolor.auth.Member;
+import com.pyonsnalcolor.auth.MemberRepository;
 import com.pyonsnalcolor.exception.PyonsnalcolorAuthException;
 import com.pyonsnalcolor.exception.model.AuthErrorCode;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/security/JwtAuthenticationFilter.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/security/JwtAuthenticationFilter.java
@@ -1,7 +1,5 @@
-package com.pyonsnalcolor.auth.jwt;
+package com.pyonsnalcolor.auth.security;
 
-import com.pyonsnalcolor.auth.AuthUserDetails;
-import com.pyonsnalcolor.auth.AuthUserDetailsService;
 import com.pyonsnalcolor.auth.RedisUtil;
 import com.pyonsnalcolor.exception.PyonsnalcolorAuthException;
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +53,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             saveAuthenticationIfValidate(accessToken);
 
         } catch (Exception e) {
-            request.setAttribute("exception", e);	// 예외를 request에 set
+            request.setAttribute("exception", e);
         }
 
         filterChain.doFilter(request, response);

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/security/JwtTokenProvider.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/security/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.pyonsnalcolor.auth.jwt;
+package com.pyonsnalcolor.auth.security;
 
 import com.pyonsnalcolor.auth.dto.TokenDto;
 import com.pyonsnalcolor.exception.PyonsnalcolorAuthException;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/service/MemberService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/auth/service/MemberService.java
@@ -10,8 +10,7 @@ import com.pyonsnalcolor.auth.oauth.OAuthClient;
 import com.pyonsnalcolor.auth.oauth.OAuthLoginService;
 import com.pyonsnalcolor.exception.PyonsnalcolorAuthException;
 import com.pyonsnalcolor.auth.RedisUtil;
-import com.pyonsnalcolor.auth.AuthUserDetails;
-import com.pyonsnalcolor.auth.jwt.JwtTokenProvider;
+import com.pyonsnalcolor.auth.security.JwtTokenProvider;
 import com.pyonsnalcolor.product.enumtype.ProductStoreType;
 import com.pyonsnalcolor.push.PushProductStore;
 import com.pyonsnalcolor.push.repository.PushKeywordRepository;
@@ -141,8 +140,8 @@ public class MemberService {
         }
     }
 
-    public void withdraw(AuthUserDetails authUserDetails) {
-        Member member = authUserDetails.getMember();
+    public void withdraw(Long memberId) {
+        Member member = memberRepository.getReferenceById(memberId);
         deletePushKeyword(member);
         deletePushProductStore(member);
         memberRepository.delete(member);
@@ -160,16 +159,16 @@ public class MemberService {
                 .forEach(pushProductStoreRepository::delete);
     }
 
-    public MemberInfoResponseDto getMemberInfo(AuthUserDetails authUserDetails) {
-        Member member = authUserDetails.getMember();
+    public MemberInfoResponseDto getMemberInfo(Long memberId) {
+        Member member = memberRepository.getReferenceById(memberId);
         return new MemberInfoResponseDto(member);
     }
 
     public void updateNickname(
-            AuthUserDetails authUserDetails,
+            Long memberId,
             NicknameRequestDto nicknameRequestDto
     ) {
-        Member member = authUserDetails.getMember();
+        Member member = memberRepository.getReferenceById(memberId);
         String updatedNickname = nicknameRequestDto.getNickname();
 
         member.updateNickname(updatedNickname);

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
@@ -41,7 +41,7 @@ public enum SevenEventTab {
 
     private static final String SEVEN_DISCOUNT_URL = "https://www.7-eleven.co.kr/product/presentView.asp";
     private static final String IMG_PREFIX = "https://www.7-eleven.co.kr";
-    private static final int TIMEOUT = 10000;
+    private static final int TIMEOUT = 15000;
 
     SevenEventTab(int tab, int startPageIndex) {
         this.tab = tab;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/SecurityConfig.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.pyonsnalcolor.config;
 
-import com.pyonsnalcolor.auth.AuthUserDetailsService;
-import com.pyonsnalcolor.auth.jwt.JwtAuthenticationFilter;
+import com.pyonsnalcolor.auth.security.AuthUserDetailsService;
+import com.pyonsnalcolor.auth.security.JwtAuthenticationFilter;
 import com.pyonsnalcolor.handler.JwtAccessDeniedHandler;
 import com.pyonsnalcolor.handler.JwtAuthenticationEntryPoint;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +24,7 @@ import org.springframework.web.client.RestTemplate;
 public class SecurityConfig {
 
     @Autowired
-    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Autowired
     JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/WebConfig.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.pyonsnalcolor.config;
+
+import com.pyonsnalcolor.auth.AuthParameterResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Autowired
+    AuthParameterResolver authParameterResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authParameterResolver);
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/model/AuthErrorCode.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/exception/model/AuthErrorCode.java
@@ -24,7 +24,8 @@ public enum AuthErrorCode implements ErrorCode {
 
     // OAuth
     OAUTH_UNAUTHORIZED(UNAUTHORIZED, "OAuth 인증에 실패했습니다."),
-    EMAIL_UNAUTHORIZED(UNAUTHORIZED, "이메일이 유효하지 않습니다.");
+    EMAIL_UNAUTHORIZED(UNAUTHORIZED, "이메일이 유효하지 않습니다."),
+    OAUTH_UNSUPPORTED(UNAUTHORIZED, "해당 OAuth 타입은 지원하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushKeywordController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushKeywordController.java
@@ -1,6 +1,6 @@
 package com.pyonsnalcolor.push.controller;
 
-import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.auth.AuthMemberId;
 import com.pyonsnalcolor.push.dto.PushKeywordRequestDto;
 import com.pyonsnalcolor.push.dto.PushKeywordResponseDto;
 import com.pyonsnalcolor.push.service.PushKeywordService;
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -27,32 +26,29 @@ public class PushKeywordController {
     @Operation(summary = "푸시 키워드 목록 조회")
     @GetMapping
     public ResponseEntity<List<PushKeywordResponseDto>> getPushKeyword(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal AuthUserDetails authUserDetails
+            @Parameter(hidden = true) @AuthMemberId Long memberId
     ) {
-        List<PushKeywordResponseDto> result = pushKeywordService.getPushKeywordResponseDto(authUserDetails);
+        List<PushKeywordResponseDto> result = pushKeywordService.getPushKeywordResponseDto(memberId);
         return new ResponseEntity(result, HttpStatus.OK);
     }
 
     @Operation(summary = "푸시 키워드 등록", description = "띄어쓰기, 특수문자없이 10자 이내")
     @PostMapping
     public ResponseEntity createPushKeyword(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @Parameter(hidden = true) @AuthMemberId Long memberId,
             @Valid @RequestBody PushKeywordRequestDto pushKeywordRequestDto
     ) {
-        pushKeywordService.createPushKeyword(authUserDetails, pushKeywordRequestDto);
+        pushKeywordService.createPushKeyword(memberId, pushKeywordRequestDto);
         return new ResponseEntity(HttpStatus.OK);
     }
 
     @Operation(summary = "푸시 키워드 삭제")
     @DeleteMapping("/{keywordId}")
     public ResponseEntity deletePushKeyword(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @Parameter(hidden = true) @AuthMemberId Long memberId,
             @PathVariable Long keywordId
     ) {
-        pushKeywordService.deletePushKeyword(authUserDetails, keywordId);
+        pushKeywordService.deletePushKeyword(memberId, keywordId);
         return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushProductStoreController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/controller/PushProductStoreController.java
@@ -1,6 +1,6 @@
 package com.pyonsnalcolor.push.controller;
 
-import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.auth.AuthMemberId;
 import com.pyonsnalcolor.push.dto.PushProductStoreRequestDto;
 import com.pyonsnalcolor.push.dto.PushProductStoreResponseDto;
 import com.pyonsnalcolor.push.service.PushProductStoreService;
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,32 +25,29 @@ public class PushProductStoreController {
     @Operation(summary = "구독 목록 조회", description = "편의점/상품별 구독 현황을 조회합니다.")
     @GetMapping
     public ResponseEntity<List<PushProductStoreResponseDto>> getPushProductStores(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal AuthUserDetails authUserDetails
+            @Parameter(hidden = true) @AuthMemberId Long memberId
     ) {
-        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(authUserDetails);
+        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(memberId);
         return new ResponseEntity(result, HttpStatus.OK);
     }
 
     @Operation(summary = "구독 신청", description = "편의점/상품별 구독을 신청합니다.")
     @PatchMapping("/subscribe")
     public ResponseEntity subscribePushProductStores(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @Parameter(hidden = true) @AuthMemberId Long memberId,
             @RequestBody PushProductStoreRequestDto pushProductStoreRequestDto
     ) {
-        pushProductStoreService.subscribePushProductStores(authUserDetails, pushProductStoreRequestDto);
+        pushProductStoreService.subscribePushProductStores(memberId, pushProductStoreRequestDto);
         return new ResponseEntity(HttpStatus.OK);
     }
 
     @Operation(summary = "구독 취소", description = "편의점/상품별 구독을 취소합니다.")
     @DeleteMapping("/unsubscribe")
     public ResponseEntity unsubscribePushProductStores(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal AuthUserDetails authUserDetails,
+            @Parameter(hidden = true) @AuthMemberId Long memberId,
             @RequestBody PushProductStoreRequestDto pushProductStoreRequestDto
     ) {
-        pushProductStoreService.unsubscribePushProductStores(authUserDetails, pushProductStoreRequestDto);
+        pushProductStoreService.unsubscribePushProductStores(memberId, pushProductStoreRequestDto);
         return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushKeywordService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushKeywordService.java
@@ -1,6 +1,6 @@
 package com.pyonsnalcolor.push.service;
 
-import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.auth.MemberRepository;
 import com.pyonsnalcolor.auth.Member;
 import com.pyonsnalcolor.exception.PyonsnalcolorPushException;
 import com.pyonsnalcolor.push.PushKeyword;
@@ -19,11 +19,13 @@ import static com.pyonsnalcolor.exception.model.PushErrorCode.*;
 @RequiredArgsConstructor
 public class PushKeywordService {
 
-    private final PushKeywordRepository pushKeywordRepository;
     private static final int PUSH_KEYWORD_NUMBER = 3;
 
-    public PushKeyword createPushKeyword(AuthUserDetails authUserDetails, PushKeywordRequestDto pushKeywordRequestDto) {
-        Member member = authUserDetails.getMember();
+    private final MemberRepository memberRepository;
+    private final PushKeywordRepository pushKeywordRepository;
+
+    public PushKeyword createPushKeyword(Long memberId, PushKeywordRequestDto pushKeywordRequestDto) {
+        Member member = memberRepository.getReferenceById(memberId);
         String pushKeywordName = pushKeywordRequestDto.getName();
 
         validatePushKeywordExist(member, pushKeywordName);
@@ -50,15 +52,15 @@ public class PushKeywordService {
         }
     }
 
-    public void deletePushKeyword(AuthUserDetails authUserDetails, Long keywordId) {
-        Member member = authUserDetails.getMember();
+    public void deletePushKeyword(Long memberId, Long keywordId) {
+        Member member = memberRepository.getReferenceById(memberId);
         PushKeyword pushKeyword = pushKeywordRepository.findByMemberAndId(member, keywordId)
                 .orElseThrow(() -> new PyonsnalcolorPushException(KEYWORD_NOT_EXIST));
         pushKeywordRepository.delete(pushKeyword);
     }
 
-    public List<PushKeywordResponseDto> getPushKeywordResponseDto(AuthUserDetails authUserDetails) {
-        Member member = authUserDetails.getMember();
+    public List<PushKeywordResponseDto> getPushKeywordResponseDto(Long memberId) {
+        Member member = memberRepository.getReferenceById(memberId);
         List<PushKeyword> pushKeywords = pushKeywordRepository.findByMember(member);
 
         return  pushKeywords.stream()

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushProductStoreService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushProductStoreService.java
@@ -21,18 +21,6 @@ public class PushProductStoreService {
 
     private final PushProductStoreRepository pushProductStoreRepository;
 
-    public void createPushProductStores (Member member) {
-        List<PushProductStore> pushProductStores = Arrays.stream(ProductStoreType.values())
-                .map( i -> PushProductStore.builder()
-                        .productStoreType(i)
-                        .member(member)
-                        .isSubscribed(true)
-                        .updatedTime(LocalDateTime.now())
-                        .build())
-                .collect(Collectors.toList());
-        pushProductStoreRepository.saveAll(pushProductStores);
-    }
-
     public List<PushProductStoreResponseDto> getPushProductStores (AuthUserDetails authUserDetails) {
         Member member = authUserDetails.getMember();
         List<PushProductStore> pushProductStores = pushProductStoreRepository.findByMember(member);

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushProductStoreService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/push/service/PushProductStoreService.java
@@ -1,6 +1,6 @@
 package com.pyonsnalcolor.push.service;
 
-import com.pyonsnalcolor.auth.AuthUserDetails;
+import com.pyonsnalcolor.auth.MemberRepository;
 import com.pyonsnalcolor.auth.Member;
 import com.pyonsnalcolor.product.enumtype.ProductStoreType;
 import com.pyonsnalcolor.push.PushProductStore;
@@ -10,8 +10,6 @@ import com.pyonsnalcolor.push.repository.PushProductStoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,9 +18,10 @@ import java.util.stream.Collectors;
 public class PushProductStoreService {
 
     private final PushProductStoreRepository pushProductStoreRepository;
+    private final MemberRepository memberRepository;
 
-    public List<PushProductStoreResponseDto> getPushProductStores (AuthUserDetails authUserDetails) {
-        Member member = authUserDetails.getMember();
+    public List<PushProductStoreResponseDto> getPushProductStores (Long memberId) {
+        Member member = memberRepository.getReferenceById(memberId);
         List<PushProductStore> pushProductStores = pushProductStoreRepository.findByMember(member);
 
         return pushProductStores.stream()
@@ -36,18 +35,18 @@ public class PushProductStoreService {
     }
 
     public void subscribePushProductStores (
-            AuthUserDetails authUserDetails,
+            Long memberId,
             PushProductStoreRequestDto pushProductStoreRequestDtos)
     {
-        Member member = authUserDetails.getMember();
+        Member member = memberRepository.getReferenceById(memberId);
         updateSubscribedStatus(member, pushProductStoreRequestDtos, true);
     }
 
     public void unsubscribePushProductStores (
-            AuthUserDetails authUserDetails,
+            Long memberId,
             PushProductStoreRequestDto pushProductStoreRequestDtos)
     {
-        Member member = authUserDetails.getMember();
+        Member member = memberRepository.getReferenceById(memberId);
         updateSubscribedStatus(member, pushProductStoreRequestDtos, false);
     }
 

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/auth/service/MemberServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/auth/service/MemberServiceTest.java
@@ -6,15 +6,11 @@ import com.pyonsnalcolor.auth.dto.LoginRequestDto;
 import com.pyonsnalcolor.auth.dto.LoginResponseDto;
 import com.pyonsnalcolor.auth.dto.MemberInfoResponseDto;
 import com.pyonsnalcolor.auth.dto.NicknameRequestDto;
-import com.pyonsnalcolor.auth.AuthUserDetails;
 import com.pyonsnalcolor.auth.enumtype.OAuthType;
 import com.pyonsnalcolor.auth.enumtype.Role;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,7 +30,6 @@ class MemberServiceTest {
     private OAuthType oAuthType;
     private String oAuthId;
     private Member member;
-    private AuthUserDetails authUserDetails;
 
     @BeforeEach
     void setUp() {
@@ -101,11 +96,11 @@ class MemberServiceTest {
     @DisplayName("사용자 정보 조회하기")
     void getMemberInfo() {
         // given
-        memberRepository.save(member);
-        setAuthentication();
+        Member savedMember = memberRepository.save(member);
+        Long memberId = savedMember.getId();
 
         // when
-        MemberInfoResponseDto memberInfoResponseDto = memberService.getMemberInfo(authUserDetails);
+        MemberInfoResponseDto memberInfoResponseDto = memberService.getMemberInfo(memberId);
 
         // then
         Assertions.assertAll(
@@ -120,26 +115,15 @@ class MemberServiceTest {
     @DisplayName("닉네임 변경하기")
     void updateNickname() throws Exception {
         // given
-        memberRepository.save(member);
-        setAuthentication();
+        Member savedMember = memberRepository.save(member);
+        Long memberId = savedMember.getId();
         String updatedNickname = "새로운 닉네임";
-        memberService.updateNickname(authUserDetails, new NicknameRequestDto(updatedNickname));
+        memberService.updateNickname(memberId, new NicknameRequestDto(updatedNickname));
 
         // when
-        Member findMember = memberRepository.findByoAuthId(oAuthId)
-                .orElseThrow(Exception::new);
+        Member findMember = memberRepository.getReferenceById(memberId);
 
         // then
         assertEquals(findMember.getNickname(), updatedNickname);
-    }
-
-    // CustomUserDetails로 Member 객체를 매핑하기 때문에 필요
-    private void setAuthentication(){
-        SecurityContext context = SecurityContextHolder.getContext();
-        authUserDetails = new AuthUserDetails(member);
-        context.setAuthentication(new UsernamePasswordAuthenticationToken(
-                authUserDetails,
-                "",
-                authUserDetails.getAuthorities()));
     }
 }

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/auth/service/MemberServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/auth/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.pyonsnalcolor.auth.service;
 
 import com.pyonsnalcolor.auth.Member;
 import com.pyonsnalcolor.auth.MemberRepository;
+import com.pyonsnalcolor.auth.dto.LoginRequestDto;
 import com.pyonsnalcolor.auth.dto.LoginResponseDto;
 import com.pyonsnalcolor.auth.dto.MemberInfoResponseDto;
 import com.pyonsnalcolor.auth.dto.NicknameRequestDto;
@@ -54,7 +55,10 @@ class MemberServiceTest {
     @DisplayName("첫 OAuth 로그인일 경우, 회원가입")
     void oAuthLogin_join() {
         // given
-        memberService.oAuthLogin(oAuthType, email);
+        LoginRequestDto loginRequestDto = LoginRequestDto.builder()
+                .token("token")
+                .oauthType("apple").build();
+        memberService.oAuthLogin(loginRequestDto);
 
         // when
         Member member = memberRepository.findByoAuthId(oAuthId)
@@ -74,7 +78,10 @@ class MemberServiceTest {
     void oAuthLogin_reLogin() {
         // given
         memberRepository.save(member); // 회원 가입 미리 되어있는 경우
-        LoginResponseDto loginResponseDto = memberService.oAuthLogin(oAuthType, email);
+        LoginRequestDto loginRequestDto = LoginRequestDto.builder()
+                .token("token")
+                .oauthType("apple").build();
+        LoginResponseDto loginResponseDto = memberService.oAuthLogin(loginRequestDto);
 
         // when
         String refreshToken = loginResponseDto.getRefreshToken();

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushProductStoreServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushProductStoreServiceTest.java
@@ -1,7 +1,5 @@
 package com.pyonsnalcolor.push.service;
 
-import com.pyonsnalcolor.auth.AuthUserDetails;
-
 import com.pyonsnalcolor.auth.Member;
 import com.pyonsnalcolor.auth.MemberRepository;
 import com.pyonsnalcolor.auth.enumtype.OAuthType;
@@ -13,9 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -46,11 +41,10 @@ class PushProductStoreServiceTest {
                 .oAuthId("apple-sample@gmail.com")
                 .refreshToken("refreshToken")
                 .role(Role.ROLE_USER).build();
-        memberRepository.save(member);
+        Member savedMember = memberRepository.save(member);
         memberService.createPushProductStores(member);
-        AuthUserDetails authUserDetails = getAuthentication(member);
 
-        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(authUserDetails);
+        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(savedMember.getId());
 
         assertAll(
                 () -> assertThat(result.size()).isEqualTo(8),
@@ -70,32 +64,20 @@ class PushProductStoreServiceTest {
                 .oAuthId("apple-sample@gmail.com")
                 .refreshToken("refreshToken")
                 .role(Role.ROLE_USER).build();
-        memberRepository.save(member);
-        memberService.createPushProductStores(member);
-        AuthUserDetails authUserDetails = getAuthentication(member);
+        Member savedMember = memberRepository.save(member);
+        memberService.createPushProductStores(savedMember);
 
         PushProductStoreRequestDto requestDto = PushProductStoreRequestDto.builder()
                 .productStores(List.of("EVENT_CU", "PB_CU"))
                 .build();
 
-        pushProductStoreService.unsubscribePushProductStores(authUserDetails, requestDto);
-        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(authUserDetails);
+        pushProductStoreService.unsubscribePushProductStores(savedMember.getId(), requestDto);
+        List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(savedMember.getId());
 
         assertAll(
                 () -> assertThat(result).filteredOn(PushProductStoreResponseDto::getProductStore, "PB_CU")
                         .filteredOn(PushProductStoreResponseDto::getIsSubscribed, false),
                 () -> assertThat(result).filteredOn(PushProductStoreResponseDto::getProductStore,"EVENT_CU")
                         .filteredOn(PushProductStoreResponseDto::getIsSubscribed, false));
-    }
-
-    // CustomUserDetails로 Member 객체를 매핑하기 때문에 필요 - 이후 수정
-    private AuthUserDetails getAuthentication(Member member){
-        SecurityContext context = SecurityContextHolder.getContext();
-        AuthUserDetails authUserDetails = new AuthUserDetails(member);
-        context.setAuthentication(new UsernamePasswordAuthenticationToken(
-                authUserDetails,
-                "",
-                authUserDetails.getAuthorities()));
-        return authUserDetails;
     }
 }

--- a/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushProductStoreServiceTest.java
+++ b/pyonsnalcolor-api/src/test/java/com/pyonsnalcolor/push/service/PushProductStoreServiceTest.java
@@ -6,6 +6,7 @@ import com.pyonsnalcolor.auth.Member;
 import com.pyonsnalcolor.auth.MemberRepository;
 import com.pyonsnalcolor.auth.enumtype.OAuthType;
 import com.pyonsnalcolor.auth.enumtype.Role;
+import com.pyonsnalcolor.auth.service.MemberService;
 import com.pyonsnalcolor.push.dto.PushProductStoreRequestDto;
 import com.pyonsnalcolor.push.dto.PushProductStoreResponseDto;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +30,10 @@ class PushProductStoreServiceTest {
     @Autowired
     private PushProductStoreService pushProductStoreService;
 
+
+    @Autowired
+    private MemberService memberService;
+
     @Autowired
     private MemberRepository memberRepository;
 
@@ -42,7 +47,7 @@ class PushProductStoreServiceTest {
                 .refreshToken("refreshToken")
                 .role(Role.ROLE_USER).build();
         memberRepository.save(member);
-        pushProductStoreService.createPushProductStores(member);
+        memberService.createPushProductStores(member);
         AuthUserDetails authUserDetails = getAuthentication(member);
 
         List<PushProductStoreResponseDto> result = pushProductStoreService.getPushProductStores(authUserDetails);
@@ -66,7 +71,7 @@ class PushProductStoreServiceTest {
                 .refreshToken("refreshToken")
                 .role(Role.ROLE_USER).build();
         memberRepository.save(member);
-        pushProductStoreService.createPushProductStores(member);
+        memberService.createPushProductStores(member);
         AuthUserDetails authUserDetails = getAuthentication(member);
 
         PushProductStoreRequestDto requestDto = PushProductStoreRequestDto.builder()


### PR DESCRIPTION
### 구현 사항
- **OAuth 로그인 api 통합** (`/auth/kakao`, `/auth/apple` -> `/auth/login`)
  - api 분리하지 않고 request dto에 OAuth 타입 전송받는 방식으로 변경
  - OAuthClient 인터페이스 만들고,  OAuthLoginService에서 해당되는 OAuth 타입별 Client 반환
- **회원가입 여부 조회 api 추가** (`/auth/status`)
- **컨트롤러 파라미터에 memberId 바인딩하도록 변경** (기존: AuthUserDetails)
  - 테스트할 때 AuthUserDetails보다 memberId로 테스트하는 게 더 간단해서 변경했습니다
  - HandlerMethodArgumentResolver 구현체 사용