### PR TITLE
Feature/meta product : 상품 관련 메타 데이터 조회 기능 추가/증정 상품 필드 추가

### DIFF
--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24EventBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24EventBatchService.java
@@ -26,7 +26,7 @@ import static com.pyonsnalcolor.product.entity.UUIDGenerator.generateId;
 @Slf4j
 public class Emart24EventBatchService extends EventBatchService {
     private static final String EMART_EVENT_URL_TEMPLATE = "http://www.emart24.co.kr/goods/event?search=&page=%s&category_seq=&align=";
-    private static final String NOT_EXIST = "NONE";
+    private static final String NOT_EXIST = null;
 
     @Autowired
     public Emart24EventBatchService(EventProductRepository eventProductRepository) {
@@ -88,10 +88,9 @@ public class Emart24EventBatchService extends EventBatchService {
         Elements originPriceElement = productElement.getElementsByClass("priceOff");
         if(originPriceElement.size() > 0) {
             originPrice = originPriceElement.get(0).text();
+            return originPrice.split(" ")[0];
         }
-
-        String parsedOriginPrice = originPrice.split(" ")[0];
-        return parsedOriginPrice;
+        return null;
     }
 
     private String parseName(Element productElement) {
@@ -130,20 +129,20 @@ public class Emart24EventBatchService extends EventBatchService {
 
     private BaseEventProduct convertToBaseEventProduct(String image, String name, String price, String originPrice, String giftImage, EventType eventType) {
         Category category = Category.matchCategoryByProductName(name);
-        Tag tag = Tag.findTag(name);
 
         BaseEventProduct baseEventProduct = BaseEventProduct.builder()
+                .id(generateId())
                 .originPrice(originPrice) //변경
                 .storeType(StoreType.EMART24)
                 .updatedTime(LocalDateTime.now())
-                .eventType(eventType) //변경
-                .id(generateId())
-                .giftImage(giftImage) //변경
+                .eventType(eventType) // 변경
+                .giftImage(giftImage) // 변경
+                .giftPrice(null)
+                .giftTitle(null)
                 .image(image)
                 .price(price)
                 .name(name)
                 .category(category)
-                .tag(tag)
                 .build();
 
         return baseEventProduct;

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25EventBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25EventBatchService.java
@@ -35,7 +35,7 @@ public class GS25EventBatchService extends EventBatchService {
     private GS25Client gs25Client;
     private ObjectMapper objectMapper;
 
-    private static final String NOT_EXIST = "NONE";
+    private static final String NOT_EXIST = null;
 
     @Autowired
     public GS25EventBatchService(EventProductRepository eventProductRepository,
@@ -106,6 +106,15 @@ public class GS25EventBatchService extends EventBatchService {
         String formattedPrice = NumberFormat.getInstance().format(priceInt);
         String eventType = (String) ((Map) productMap.get("eventTypeSp")).get("code");
         String giftImage = (String) productMap.get("giftAttFileNm");
+        String giftTitle = (String) productMap.get("giftGoodsNm");
+        Double giftPriceDouble = (Double) productMap.get("giftPrice");
+        String formattedGiftPrice = null;
+        if (giftPriceDouble != null) {
+            String giftPrice =  Double.toString(giftPriceDouble).split("\\.")[0];
+            int giftPriceInt = Integer.parseInt(giftPrice);
+            formattedGiftPrice = NumberFormat.getInstance().format(giftPriceInt);
+        }
+
         Category category = Category.matchCategoryByProductName(name);
         Tag tag = Tag.findTag(name);
 
@@ -113,9 +122,11 @@ public class GS25EventBatchService extends EventBatchService {
                 .originPrice(NOT_EXIST)
                 .storeType(StoreType.GS25)
                 .updatedTime(LocalDateTime.now())
-                .eventType(EventType.getEventTypeWithValue(eventType))
+                .eventType(EventType.valueOf(eventType))
                 .id(generateId())
                 .giftImage(giftImage)
+                .giftTitle(giftTitle)
+                .giftPrice(formattedGiftPrice)
                 .image(image)
                 .price(formattedPrice)
                 .name(name)

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25PbBatchService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25PbBatchService.java
@@ -34,7 +34,7 @@ public class GS25PbBatchService extends PbBatchService {
     private GS25Client gs25Client;
     private ObjectMapper objectMapper;
 
-    private static final String NOT_EXIST = "NONE";
+    private static final String NOT_EXIST = null;
 
     @Autowired
     public GS25PbBatchService(PbProductRepository pbProductRepository,

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
@@ -71,7 +71,7 @@ public enum SevenEventTab {
         String name = originElement.select("div.name").first().text();
         String image = IMG_PREFIX + originElement.select("img").first().attr("src");
         String price = originElement.select("div.price").text();
-        EventType eventType = EventType.getEventTypeWithValue(this.name());
+        EventType eventType = EventType.valueOf(this.name());
 
         String originPrice = null;
         if (this == DISCOUNT) {
@@ -79,8 +79,12 @@ public enum SevenEventTab {
             originPrice = getOriginPrice(originProductCode);
         }
         String giftImage = null;
+        String giftTitle = null;
+        String giftPrice = null;
         if (this == GIFT) {
             giftImage = IMG_PREFIX + subElement.select("img").first().attr("src");
+            giftTitle = subElement.select("div.infowrap div.name").text();
+            giftPrice = subElement.select("div.infowrap div.price span").text();
         }
         Category category = Category.matchCategoryByProductName(name);
         Tag tag = Tag.findTag(name);
@@ -91,6 +95,8 @@ public enum SevenEventTab {
                 .image(image)
                 .price(price)
                 .giftImage(giftImage)
+                .giftTitle(giftTitle)
+                .giftPrice(giftPrice)
                 .originPrice(originPrice)
                 .updatedTime(LocalDateTime.now())
                 .eventType(eventType)

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/EventProductController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/EventProductController.java
@@ -26,17 +26,17 @@ public class EventProductController {
     @Parameter(name = "storeType", description = "편의점 종류(seven_eleven, cu, gs25, emart24, all)")
     @Parameter(name = "sorted", description = "정렬순서")
     @GetMapping("/products/event-products")
-    public Page<ProductResponseDto> getEventProducts(@RequestParam("pageNumber") int pageNumber,
-                                                     @RequestParam("pageSize") int pageSize,
-                                                     @RequestParam(
+    public Page<EventProductResponseDto> getEventProducts(@RequestParam("pageNumber") int pageNumber,
+                                                          @RequestParam("pageSize") int pageSize,
+                                                          @RequestParam(
                                                            value = "storeType",
                                                            defaultValue = "all"
                                                    ) String storeType,
-                                                     @RequestParam(
+                                                          @RequestParam(
                                                            value = "sorted",
                                                            defaultValue = "updatedTime"
                                                    ) String sorted) {
-        return eventProductService.getProductsWithPaging(pageNumber, pageSize, storeType, sorted);
+        return eventProductService.getProductsByPaging(pageNumber, pageSize, storeType, sorted);
     }
 
     @Operation(summary = "이벤트 상품 단건 조회", description = "id 바탕으로 이벤트 상품을 조회합니다.")

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/EventProductController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/EventProductController.java
@@ -2,10 +2,8 @@ package com.pyonsnalcolor.product.controller;
 
 import com.pyonsnalcolor.product.dto.EventProductResponseDto;
 import com.pyonsnalcolor.product.dto.ProductResponseDto;
-import com.pyonsnalcolor.product.entity.BaseEventProduct;
 import com.pyonsnalcolor.product.service.EventProductService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,21 +19,13 @@ public class EventProductController {
     private final EventProductService eventProductService;
 
     @Operation(summary = "이벤트 상품 조회", description = "이벤트 상품을 조회합니다.")
-    @Parameter(name = "pageNumber", description = "조회할 페이지 번호")
-    @Parameter(name = "pageSize", description = "페이지별 상품 갯수")
-    @Parameter(name = "storeType", description = "편의점 종류(seven_eleven, cu, gs25, emart24, all)")
-    @Parameter(name = "sorted", description = "정렬순서")
-    @GetMapping("/products/event-products")
-    public Page<EventProductResponseDto> getEventProducts(@RequestParam("pageNumber") int pageNumber,
-                                                          @RequestParam("pageSize") int pageSize,
-                                                          @RequestParam(
-                                                           value = "storeType",
-                                                           defaultValue = "all"
-                                                   ) String storeType,
-                                                          @RequestParam(
-                                                           value = "sorted",
-                                                           defaultValue = "updatedTime"
-                                                   ) String sorted) {
+    @GetMapping("/products/event")
+    public Page<EventProductResponseDto> getEventProducts(
+            @RequestParam(value = "pageNumber") int pageNumber,
+            @RequestParam(value = "pageSize") int pageSize,
+            @RequestParam(value = "storeType", defaultValue = "all") String storeType,
+            @RequestParam(value = "sorted", defaultValue = "updatedTime") String sorted
+    ) {
         return eventProductService.getProductsByPaging(pageNumber, pageSize, storeType, sorted);
     }
 

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/PbProductController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/PbProductController.java
@@ -1,8 +1,6 @@
 package com.pyonsnalcolor.product.controller;
 
-
 import com.pyonsnalcolor.product.dto.ProductResponseDto;
-import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.service.PbProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -43,7 +41,6 @@ public class PbProductController {
     @GetMapping("/products/pb-products/{id}")
     public ProductResponseDto getPbProducts(@PathVariable String id) throws Throwable {
         ProductResponseDto product = pbProductService.getProduct(id);
-
-   return product;
+        return product;
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/ProductMetaDataController.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/controller/ProductMetaDataController.java
@@ -1,0 +1,37 @@
+package com.pyonsnalcolor.product.controller;
+
+import com.pyonsnalcolor.product.dto.ProductMetaDataDto;
+import com.pyonsnalcolor.product.dto.ProductMetaDataResponseDto;
+import com.pyonsnalcolor.product.enumtype.Category;
+import com.pyonsnalcolor.product.enumtype.EventType;
+import com.pyonsnalcolor.product.enumtype.Sorted;
+import com.pyonsnalcolor.product.enumtype.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@io.swagger.v3.oas.annotations.tags.Tag(name = "상품 메타 데이터 api")
+@RestController
+@RequiredArgsConstructor
+public class ProductMetaDataController {
+
+    @Operation(summary = "상품 정렬 키값 조회", description = "정렬 관련 키값을 조회합니다.")
+    @GetMapping("/products/meta-data")
+    public ResponseEntity<ProductMetaDataDto> getProductsMetaDataList() {
+
+        ProductMetaDataDto productMetaDataDto = ProductMetaDataDto.builder()
+                .sortedMeta(Sorted.getSortedWithCodes())
+                .tagMetaData(Tag.getTagWithCodes())
+                .categoryMetaData(Category.getCategoryWithCodes())
+                .eventMetaData(EventType.getEventWithCodes())
+                .build();
+
+        ProductMetaDataResponseDto productMetaDataResponseDto = ProductMetaDataResponseDto.builder()
+                .metaDataList(productMetaDataDto)
+                .build();
+        return new ResponseEntity(productMetaDataResponseDto, HttpStatus.OK);
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/dto/EventProductResponseDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/dto/EventProductResponseDto.java
@@ -1,5 +1,6 @@
 package com.pyonsnalcolor.product.dto;
 
+import com.pyonsnalcolor.product.enumtype.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,6 @@ import lombok.experimental.SuperBuilder;
 
 import javax.validation.constraints.NotBlank;
 
-
 @Schema(description = "이벤트 상품 조회 Response DTO")
 @SuperBuilder
 @ToString(callSuper = true)
@@ -16,7 +16,9 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class EventProductResponseDto extends ProductResponseDto {
     @NotBlank
+    private EventType eventType;
     private String originPrice;
-    @NotBlank
     private String giftImage;
+    private String giftTitle;
+    private String giftPrice;
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/dto/MetaDataDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/dto/MetaDataDto.java
@@ -1,0 +1,14 @@
+package com.pyonsnalcolor.product.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MetaDataDto {
+
+    private String name;
+    private Long code;
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/dto/ProductMetaDataDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/dto/ProductMetaDataDto.java
@@ -1,0 +1,23 @@
+package com.pyonsnalcolor.product.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProductMetaDataDto {
+
+    @NotBlank
+    private List<MetaDataDto> sortedMeta;
+    @NotBlank
+    private List<MetaDataDto> tagMetaData;
+    @NotBlank
+    private List<MetaDataDto> categoryMetaData;
+    @NotBlank
+    private List<MetaDataDto> eventMetaData;
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/dto/ProductMetaDataResponseDto.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/dto/ProductMetaDataResponseDto.java
@@ -1,0 +1,13 @@
+package com.pyonsnalcolor.product.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProductMetaDataResponseDto {
+
+    private ProductMetaDataDto metaDataList;
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/entity/BaseEventProduct.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/entity/BaseEventProduct.java
@@ -1,7 +1,6 @@
 package com.pyonsnalcolor.product.entity;
 
 import com.pyonsnalcolor.product.dto.EventProductResponseDto;
-import com.pyonsnalcolor.product.dto.ProductResponseDto;
 import com.pyonsnalcolor.product.enumtype.EventType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,9 +18,11 @@ public class BaseEventProduct extends BaseProduct {
     private EventType eventType;
     private String originPrice;
     private String giftImage;
+    private String giftTitle;
+    private String giftPrice;
 
     @Override
-    public ProductResponseDto convertToDto() {
+    public EventProductResponseDto convertToDto() {
         return EventProductResponseDto.builder()
                 .id(getId())
                 .name(getName())
@@ -33,6 +34,8 @@ public class BaseEventProduct extends BaseProduct {
                 .eventType(getEventType())
                 .originPrice(getOriginPrice())
                 .giftImage(getGiftImage())
+                .giftPrice(getGiftPrice())
+                .giftTitle(getGiftTitle())
                 .isNew(true)
                 .build();
     }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/enumtype/Category.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/enumtype/Category.java
@@ -1,36 +1,39 @@
 package com.pyonsnalcolor.product.enumtype;
 
+import com.pyonsnalcolor.product.dto.MetaDataDto;
 import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public enum Category {
 
-    GOODS("생활용품", Arrays.asList("세제", "샴푸", "린스", "페브리즈", "좋은", "치약", "칫솔", "극세모", "미세모",
-            "클렌징폼", "면도", "대형", "중형", "소형", "실내", "클렌징", "오일", "피죤", "유기농", "로션", "크림", "립밤", "티슈",
-            "바디", "쏘피", "스프레이", "니베아", "마스크", "샤프란", "가그린", "가글", "주방")),
-    CONVENIENCE_FOOD("간편식사", Arrays.asList("그래놀라", "시리얼", "컵밥", "교자", "사발",
-            "큰컵", "소컵", "라면", "수프", "닭가슴살", "도시락", "떡볶이", "햇반", "버거", "호빵"
-    )),
-    FOOD("식품", Arrays.asList("오뚜기", "비비고", "만두", "김치", "교자", "탕", "양념", "우동", "육즙", "스파게티", "스팸",
-            "쫄면", "참치", "리챔", "국", "라멘", "파스타", "양념", "떡볶이", "오뚜기", "밥", "죽", "김", "미식"
-    )),
-    DRINK("음료", Arrays.asList("ml", "두유", "제로", "나랑드", "병", "매일", "헛개", "라떼", "밀크티", "아메", "덴마크)",
-            "우유", "요구르트", "얼그레이", "밀키스", "홍차", "차", "쌍화", "콤부차", "남양", "밀크", "커피", "할리스", "에이드"
-    )),
-    SNACK("과자", Arrays.asList("파이", "오레오", "와플", "꼬깔콘", "산도", "캔디", "썬", "쿠키", "맛동산", "카라멜",
-            "비스켓", "로아커", "감자", "스낵", "해태", "껌", "샌드", "사탕", "젤리", "캔디", "비요뜨", "크래커", "양갱", "오리온")),
-    ICE_CREAM("아이스크림", Arrays.asList("파르페", "탱크보이", "슈퍼콘", "월드콘", "우유콘", "설레임", "아이스", "하겐다즈",
-            "부라보콘", "메로나", "죠스바", "구구콘", "수박바", "비비빅", "쌍쌍바", "쉐이크", "스크류바", "옥동자", "찰옥수수",
-            "더블비얀코", "보석바", "돼지바", "빠삐코", "빵빠레")),
-    BAKERY("베이커리", Arrays.asList("케익", "빵", "카스테라", "도넛", "마들렌"));
+    GOODS(1001L, "생활용품", Arrays.asList("세제", "샴푸", "린스", "페브리즈", "좋은", "치약", "칫솔", "극세모",
+            "미세모", "클렌징폼", "면도", "대형", "중형", "소형", "실내", "클렌징", "오일", "피죤", "유기농", "로션", "크림",
+            "립밤", "티슈", "바디", "쏘피", "스프레이", "니베아", "마스크", "샤프란", "가그린", "가글", "주방")),
+    FOOD(1002L, "식품", Arrays.asList("그래놀라", "시리얼", "컵밥", "교자", "사발", "큰컵", "소컵", "라면",
+            "수프", "닭가슴살", "도시락", "떡볶이", "햇반", "버거", "호빵", "오뚜기", "비비고", "만두", "김치", "교자", "탕",
+            "양념", "우동", "육즙", "스파게티", "스팸", "쫄면", "참치", "리챔", "국", "라멘", "파스타", "양념", "떡볶이",
+            "오뚜기", "밥", "죽", "김", "미식")),
+    DRINK(1003L, "음료", Arrays.asList("ml", "두유", "제로", "나랑드", "병", "매일", "헛개", "라떼", "밀크티",
+            "아메", "덴마크)", "우유", "요구르트", "얼그레이", "밀키스", "홍차", "차", "쌍화", "콤부차", "남양", "밀크", "커피",
+            "할리스", "에이드")),
+    SNACK(1004L, "과자", Arrays.asList("파이", "오레오", "와플", "꼬깔콘", "산도", "캔디", "썬", "쿠키", "맛동산",
+            "카라멜", "비스켓", "로아커", "감자", "스낵", "해태", "껌", "샌드", "사탕", "젤리", "캔디", "비요뜨", "크래커", "양갱",
+            "오리온")),
+    ICE_CREAM(1005L, "아이스크림", Arrays.asList("파르페", "탱크보이", "슈퍼콘", "월드콘", "우유콘", "설레임",
+            "아이스", "하겐다즈", "부라보콘", "메로나", "죠스바", "구구콘", "수박바", "비비빅", "쌍쌍바", "쉐이크", "스크류바",
+            "옥동자", "찰옥수수", "더블비얀코", "보석바", "돼지바", "빠삐코", "빵빠레")),
+    BAKERY(1006L, "베이커리", Arrays.asList("케익", "빵", "카스테라", "도넛", "마들렌"));
 
+    private final Long code;
     private final String korean;
     private final List<String> keywords;
 
-    Category(String korean, List<String> keywords) {
+    Category(Long code, String korean, List<String> keywords) {
+        this.code = code;
         this.korean = korean;
         this.keywords = keywords;
     }
@@ -42,5 +45,15 @@ public enum Category {
                         .anyMatch(name::contains))
                 .findFirst()
                 .orElse(null);
+    }
+
+    public static List<MetaDataDto> getCategoryWithCodes() {
+
+        return Arrays.stream(Category.values())
+                .map(category -> MetaDataDto.builder()
+                        .name(category.korean)
+                        .code(category.code)
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/enumtype/EventType.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/enumtype/EventType.java
@@ -1,27 +1,33 @@
 package com.pyonsnalcolor.product.enumtype;
 
+import com.pyonsnalcolor.product.dto.MetaDataDto;
 import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public enum EventType {
-    ONE_TO_ONE("ONE_TO_ONE"),
-    TWO_TO_ONE("TWO_TO_ONE"),
-    THREE_TO_ONE("THREE_TO_ONE"),
-    GIFT("GIFT"),
-    DISCOUNT("DISCOUNT");
+    ONE_TO_ONE(10001L),
+    TWO_TO_ONE(10002L),
+    THREE_TO_ONE(10003L),
+    GIFT(10004L),
+    DISCOUNT(10005L);
 
-    private String value;
+    private final Long code;
 
-    EventType(String value) {
-        this.value = value;
+    EventType(Long code) {
+        this.code = code;
     }
 
-    public static EventType getEventTypeWithValue(String value) {
-        for (EventType e : values()) {
-            if (e.value.equals(value)) {
-                return e;
-            }
-        }
-        return null;
+    public static List<MetaDataDto> getEventWithCodes() {
+
+        return Arrays.stream(EventType.values())
+                .map(event -> MetaDataDto.builder()
+                        .name(event.name())
+                        .code(event.code)
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/enumtype/Sorted.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/enumtype/Sorted.java
@@ -1,0 +1,47 @@
+package com.pyonsnalcolor.product.enumtype;
+
+import com.pyonsnalcolor.product.dto.MetaDataDto;
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public enum Sorted {
+    LATEST(1L, "최신순", Sort.by("updatedTime").descending()),
+    VIEW(2L, "조회순", Sort.by("updatedTime")),
+    LOW_PRICE(3L, "가격낮은순", Sort.by("price").ascending()),
+    HIGH_PRICE(4L, "가격높은순", Sort.by("price").descending()),
+    REVIEW(5L, "리뷰순", Sort.by("updatedTime"));
+
+    private final Long code;
+    private final String korean;
+    private final Sort sort;
+
+    Sorted(Long code, String korean, Sort sort) {
+        this.code = code;
+        this.korean = korean;
+        this.sort = sort;
+    }
+
+    public static List<MetaDataDto> getSortedWithCodes() {
+
+        return Arrays.stream(Sorted.values())
+                .map(sorted -> MetaDataDto.builder()
+                        .name(sorted.korean)
+                        .code(sorted.code)
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public static Sort getSortByCode(Long code) {
+
+        return Arrays.stream(Sorted.values())
+                .filter(sorted -> sorted.code.equals(code))
+                .findFirst()
+                .map(Sorted::getSort)
+                .orElseThrow();
+    }
+}

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/enumtype/Tag.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/enumtype/Tag.java
@@ -1,33 +1,40 @@
 package com.pyonsnalcolor.product.enumtype;
 
+import com.pyonsnalcolor.product.dto.MetaDataDto;
 import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public enum Tag {
 
-    FATIGUE_RECOVER("피로회복", Arrays.asList("비타", "과일", "액티비아", "에너지", "종근당", "인삼", "홍삼", "보약")),
-    WINTER("겨울음식", Arrays.asList("우동", "오뎅", "호빵", "북엇국")),
-    DIET("다이어트", Arrays.asList("제로", "라이트", "닭가슴살", "무설탕", "그래놀라", "곤약")),
-    CHARACTER("캐릭터", Arrays.asList("포켓몬", "짱구", "원피스")),
-    SPICY("매운", Arrays.asList("불닭", "사천", "엽떡", "마라", "매콤", "할라피뇨", "떡볶이")),
-    HANGOVER("해장", Arrays.asList("헛개", "수프", "국")),
-    DRINK_SNACK("안주", Arrays.asList("김부각", "어묵바", "오징어", "젤리", "소시지", "땅콩", "믹스넛",
+    NIGHT_WORK(101L, "밤샘", Arrays.asList("비타", "과일", "액티비아", "에너지", "종근당", "인삼", "홍삼",
+            "보약", "카페인", "녹차", "커피", "껌")),
+    DIET(102L, "다이어트", Arrays.asList("제로", "라이트", "닭가슴살", "무설탕", "그래놀라", "곤약")),
+    CHARACTER(103L, "캐릭터", Arrays.asList("포켓몬", "짱구", "원피스")),
+    SPICY(104L, "매운", Arrays.asList("불닭", "사천", "엽떡", "마라", "매콤", "할라피뇨", "떡볶이")),
+    DRINK_SNACK(105L, "간식", Arrays.asList("김부각", "어묵바", "오징어", "젤리", "소시지", "땅콩", "믹스넛",
             "후랑크", "아몬드", "안주", "오뎅", "치즈", "육포")),
-    SWEET("달달", Arrays.asList("초코", "초콜릿", "키세스", "허쉬", "킷캣", "쿠앤크", "팥",
+    SWEET(106L, "달달", Arrays.asList("초코", "초콜릿", "키세스", "허쉬", "킷캣", "쿠앤크", "팥",
             "바닐라", "허니", "빙수", "젤리")),
-    ALONE("혼밥", Arrays.asList("김밥", "컵밥", "큰컵")),
-    MIDNIGHT_SNACK("야식", Arrays.asList("닭발", "후랑크", "버거", "라면", "샌드위치", "치킨")),
-    HUNGRY_SNACKS("요깃거리", Arrays.asList("구운란", "군밤", "소시지", "고구마", "계란", "비엔나")),
-    NIGHT_WORK("밤샘", Arrays.asList("카페인", "녹차", "커피", "껌")),
-    EXERCISE("운동", Arrays.asList("프로틴", "이온", "단백질", "에너지바"));
+    ALONE(107L, "혼밥", Arrays.asList("김밥", "컵밥", "큰컵")),
+    POPULAR(108L, "인기있는", Arrays.asList());
+    // TODO: 이후에 추가될 항목들
+    // MIDNIGHT_SNACK(code, "야식", Arrays.asList("닭발", "후랑크", "버거", "라면", "샌드위치", "치킨")),
+    // HANGOVER(code, "해장", Arrays.asList("헛개", "수프", "국", "우동", "오뎅", "호빵", "북엇국")),
+    // HUNGRY_SNACKS("요깃거리", Arrays.asList("구운란", "군밤", "소시지", "고구마", "계란", "비엔나")),
+    // NIGHT_WORK("밤샘", Arrays.asList("카페인", "녹차", "커피", "껌")),
+    // EXERCISE("운동", Arrays.asList("프로틴", "이온", "단백질", "에너지바"));
 
+
+    private final Long code;
     private final String korean;
     private final List<String> keywords;
 
-    Tag(String korean, List<String> keywords) {
+    Tag(Long code, String korean, List<String> keywords) {
+        this.code = code;
         this.korean = korean;
         this.keywords = keywords;
     }
@@ -39,5 +46,15 @@ public enum Tag {
                         .anyMatch(name::contains))
                 .findFirst()
                 .orElse(null);
+    }
+
+    public static List<MetaDataDto> getTagWithCodes() {
+
+        return Arrays.stream(Tag.values())
+                .map(tag -> MetaDataDto.builder()
+                        .name(tag.korean)
+                        .code(tag.code)
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/service/EventProductService.java
+++ b/pyonsnalcolor-api/src/main/java/com/pyonsnalcolor/product/service/EventProductService.java
@@ -1,12 +1,48 @@
 package com.pyonsnalcolor.product.service;
 
+import com.pyonsnalcolor.product.dto.EventProductResponseDto;
+import com.pyonsnalcolor.product.dto.ProductResponseDto;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
+import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.product.repository.EventProductRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
 public class EventProductService extends ProductService<BaseEventProduct> {
+
     public EventProductService(EventProductRepository eventProductRepository) {
         super(eventProductRepository);
+    }
+
+    public Page<EventProductResponseDto> getProductsByPaging(int pageNumber, int pageSize, String storeType, String sorted) {
+
+        Sort sort = Sort.by("updatedTime").descending().and(Sort.by("id"));
+        String storeTypeUppercase = storeType.toUpperCase();
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, sort);
+
+        if (storeTypeUppercase.equals("ALL")) {
+            Page<BaseEventProduct> products = basicProductRepository.findAll(pageRequest);
+            return convertToEventProductResponseDto(products);
+        }
+        StoreType storeTypeEnum = StoreType.valueOf(storeTypeUppercase);
+        Page<BaseEventProduct> products = basicProductRepository.findByStoreType(storeTypeEnum, pageRequest);
+        return convertToEventProductResponseDto(products);
+    }
+
+    private Page<EventProductResponseDto> convertToEventProductResponseDto(Page<BaseEventProduct> products) {
+        List<EventProductResponseDto> productResponseDtos = products.getContent().stream()
+                .map(BaseEventProduct::convertToDto)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(productResponseDtos, products.getPageable(), products.getTotalElements());
     }
 }


### PR DESCRIPTION
### 구현 사항
- **상품 관련 메타 데이터 조회 기능 추가**
- **증정 제품 가격/증정 제품 제목 필드 추가**


### 참고 사항
- **조회관련 정렬/페이징은 이후 일괄 추가/변경 예정**
- 증정 관련 참고
  - GS : 증정 이미지/제목/가격
  - SEVEN : 증정 이미지/제목/가격
  - EMART : 증정 이미지만, 나머지는 null 필드
  - CU : 증정 제품X
- 메타 데이터 예시
```
{
  "metaDataList": {
    "sortedMeta": [
      {
        "name": "최신순",
        "code": 1
      },
      {
        "name": "조회순",
        "code": 2
      }, ...
    ],
    "tagMetaData": [
      {
        "name": "밤샘",
        "code": 101
      },
      {
        "name": "다이어트",
        "code": 102
      }, ...
    ]
  }
}

```