### PR TITLE
Feature/product filter 상품 정렬, 필터링 조회 구현

### DIFF
--- a/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
@@ -3,10 +3,7 @@ package com.pyonsnalcolor.batch.service.cu;
 import com.pyonsnalcolor.batch.service.EventBatchService;
 import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
-import com.pyonsnalcolor.product.enumtype.Category;
-import com.pyonsnalcolor.product.enumtype.EventType;
-import com.pyonsnalcolor.product.enumtype.Recommend;
-import com.pyonsnalcolor.product.enumtype.StoreType;
+import com.pyonsnalcolor.product.enumtype.*;
 import com.pyonsnalcolor.product.repository.EventProductRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -88,8 +85,7 @@ public class CuEventBatchService extends EventBatchService implements CuDescript
         EventType eventType = getCuEventType(eventTypeTag);
 
         String description = getDescription(element, "event");
-        Category category = Category.matchCategoryByProductName(name);
-        Recommend recommend = Recommend.matchRecommendByProductName(name);
+        Category category = Filter.matchEnumTypeByProductName(Category.class, name);
 
         return BaseEventProduct.builder()
                 .id((generateId()))
@@ -101,7 +97,6 @@ public class CuEventBatchService extends EventBatchService implements CuDescript
                 .storeType(StoreType.CU)
                 .updatedTime(LocalDateTime.now())
                 .category(category)
-                .recommend(recommend)
                 .build();
     }
 

--- a/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
@@ -5,6 +5,7 @@ import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
 import com.pyonsnalcolor.exception.model.BatchErrorCode;
 import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.enumtype.Category;
+import com.pyonsnalcolor.product.enumtype.Filter;
 import com.pyonsnalcolor.product.enumtype.Recommend;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.product.repository.PbProductRepository;
@@ -92,8 +93,8 @@ public class CuPbBatchService extends PbBatchService implements CuDescriptionBat
         }
         String price = element.select("div.price > strong").first().text();
         String description = getDescription(element, "product");
-        Category category = Category.matchCategoryByProductName(name);
-        Recommend recommend = Recommend.matchRecommendByProductName(name);
+        Category category = Filter.matchEnumTypeByProductName(Category.class, name);
+        Recommend recommend = Filter.matchEnumTypeByProductName(Recommend.class, name);
 
         return BasePbProduct.builder()
                 .id((generateId()))

--- a/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24EventBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24EventBatchService.java
@@ -2,9 +2,7 @@ package com.pyonsnalcolor.batch.service.emart24;
 
 import com.pyonsnalcolor.batch.service.EventBatchService;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
-import com.pyonsnalcolor.product.enumtype.Category;
-import com.pyonsnalcolor.product.enumtype.EventType;
-import com.pyonsnalcolor.product.enumtype.StoreType;
+import com.pyonsnalcolor.product.enumtype.*;
 import com.pyonsnalcolor.product.repository.EventProductRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -115,8 +113,6 @@ public class Emart24EventBatchService extends EventBatchService {
                 return EventType.GIFT;
             case "sale":
                 return EventType.DISCOUNT;
-            case "tripl":
-                return EventType.THREE_TO_ONE;
             case "twopl":
                 return EventType.TWO_TO_ONE;
             case "onepl":
@@ -127,7 +123,7 @@ public class Emart24EventBatchService extends EventBatchService {
     }
 
     private BaseEventProduct convertToBaseEventProduct(String image, String name, String price, String originPrice, String giftImage, EventType eventType) {
-        Category category = Category.matchCategoryByProductName(name);
+        Category category = Filter.matchEnumTypeByProductName(Category.class, name);
 
         BaseEventProduct baseEventProduct = BaseEventProduct.builder()
                 .id(generateId())

--- a/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PbBatchService.java
@@ -3,6 +3,7 @@ package com.pyonsnalcolor.batch.service.emart24;
 import com.pyonsnalcolor.batch.service.PbBatchService;
 import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.enumtype.Category;
+import com.pyonsnalcolor.product.enumtype.Filter;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.product.enumtype.Recommend;
 import com.pyonsnalcolor.product.repository.PbProductRepository;
@@ -71,8 +72,8 @@ public class Emart24PbBatchService extends PbBatchService {
     }
 
     private BasePbProduct convertToBasePbProduct(String image, String name, String price) {
-        Category category = Category.matchCategoryByProductName(name);
-        Recommend recommend = Recommend.matchRecommendByProductName(name);
+        Category category = Filter.matchEnumTypeByProductName(Category.class, name);
+        Recommend recommend = Filter.matchEnumTypeByProductName(Recommend.class, name);
 
         BasePbProduct basePbProduct = BasePbProduct.builder()
                 .id(generateId())

--- a/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25EventBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25EventBatchService.java
@@ -6,10 +6,7 @@ import com.pyonsnalcolor.batch.client.GS25Client;
 import com.pyonsnalcolor.batch.client.GS25EventRequestBody;
 import com.pyonsnalcolor.batch.service.EventBatchService;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
-import com.pyonsnalcolor.product.enumtype.Category;
-import com.pyonsnalcolor.product.enumtype.EventType;
-import com.pyonsnalcolor.product.enumtype.Recommend;
-import com.pyonsnalcolor.product.enumtype.StoreType;
+import com.pyonsnalcolor.product.enumtype.*;
 import com.pyonsnalcolor.product.repository.EventProductRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Connection;
@@ -115,8 +112,7 @@ public class GS25EventBatchService extends EventBatchService {
             formattedGiftPrice = NumberFormat.getInstance().format(giftPriceInt);
         }
 
-        Category category = Category.matchCategoryByProductName(name);
-        Recommend recommend = Recommend.matchRecommendByProductName(name);
+        Category category = Filter.matchEnumTypeByProductName(Category.class, name);
 
         BaseEventProduct baseEventProduct = BaseEventProduct.builder()
                 .originPrice(NOT_EXIST)
@@ -131,7 +127,6 @@ public class GS25EventBatchService extends EventBatchService {
                 .price(formattedPrice)
                 .name(name)
                 .category(category)
-                .recommend(recommend)
                 .build();
 
         return baseEventProduct;

--- a/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25PbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25PbBatchService.java
@@ -7,6 +7,7 @@ import com.pyonsnalcolor.batch.client.GS25PbRequestBody;
 import com.pyonsnalcolor.batch.service.PbBatchService;
 import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.enumtype.Category;
+import com.pyonsnalcolor.product.enumtype.Filter;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.product.enumtype.Recommend;
 import com.pyonsnalcolor.product.repository.PbProductRepository;
@@ -96,8 +97,8 @@ public class GS25PbBatchService extends PbBatchService {
         int priceInt = Integer.parseInt(price);
         String formattedPrice = NumberFormat.getInstance().format(priceInt);
 
-        Category category = Category.matchCategoryByProductName(name);
-        Recommend recommend = Recommend.matchRecommendByProductName(name);
+        Category category = Filter.matchEnumTypeByProductName(Category.class, name);
+        Recommend recommend = Filter.matchEnumTypeByProductName(Recommend.class, name);
 
         BasePbProduct basePbProduct = BasePbProduct.builder()
                 .id(generateId())

--- a/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
@@ -2,10 +2,7 @@ package com.pyonsnalcolor.batch.service.seven;
 
 import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
-import com.pyonsnalcolor.product.enumtype.Category;
-import com.pyonsnalcolor.product.enumtype.EventType;
-import com.pyonsnalcolor.product.enumtype.Recommend;
-import com.pyonsnalcolor.product.enumtype.StoreType;
+import com.pyonsnalcolor.product.enumtype.*;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -85,8 +82,7 @@ public enum SevenEventTab {
             giftTitle = subElement.select("div.infowrap div.name").text();
             giftPrice = subElement.select("div.infowrap div.price span").text();
         }
-        Category category = Category.matchCategoryByProductName(name);
-        Recommend recommend = Recommend.matchRecommendByProductName(name);
+        Category category = Filter.matchEnumTypeByProductName(Category.class, name);
 
         return BaseEventProduct.builder()
                 .name(name)
@@ -101,7 +97,6 @@ public enum SevenEventTab {
                 .eventType(eventType)
                 .storeType(StoreType.SEVEN_ELEVEN)
                 .category(category)
-                .recommend(recommend)
                 .build();
     }
 

--- a/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
@@ -4,6 +4,7 @@ import com.pyonsnalcolor.batch.service.PbBatchService;
 import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
 import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.enumtype.Category;
+import com.pyonsnalcolor.product.enumtype.Filter;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.product.enumtype.Recommend;
 import com.pyonsnalcolor.product.repository.PbProductRepository;
@@ -81,8 +82,8 @@ public class SevenPbBatchService extends PbBatchService {
         String name = element.select("div.name").first().text();
         String image = IMG_PREFIX + element.select("img").first().attr("src");
         String price = element.select("div.price").text();
-        Category category = Category.matchCategoryByProductName(name);
-        Recommend recommend = Recommend.matchRecommendByProductName(name);
+        Category category = Filter.matchEnumTypeByProductName(Category.class, name);
+        Recommend recommend = Filter.matchEnumTypeByProductName(Recommend.class, name);
 
         return BasePbProduct.builder()
                 .id(generateId())

--- a/src/main/java/com/pyonsnalcolor/config/MongoDBConfig.java
+++ b/src/main/java/com/pyonsnalcolor/config/MongoDBConfig.java
@@ -1,0 +1,25 @@
+package com.pyonsnalcolor.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+
+@Configuration
+public class MongoDBConfig {
+
+    @Value("${spring.data.mongodb.uri}")
+    private String mongoDbUri;
+
+    @Bean
+    public MongoDatabaseFactory mongoDatabaseFactory() {
+        return new SimpleMongoClientDatabaseFactory(mongoDbUri);
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate() {
+        return new MongoTemplate(mongoDatabaseFactory());
+    }
+}

--- a/src/main/java/com/pyonsnalcolor/config/SecurityConfig.java
+++ b/src/main/java/com/pyonsnalcolor/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
                 .authorizeRequests()
-                .antMatchers("/auth/**", "/products/**", "/promotions/**", "/fcm/**", "/manage/**").permitAll()
+                .antMatchers("/auth/**", "/products/**",
+                        "/promotions/**", "/fcm/**", "/manage/**").permitAll()
                 .antMatchers("/member/**").hasRole("USER")
                 .anyRequest().authenticated()
             .and()

--- a/src/main/java/com/pyonsnalcolor/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pyonsnalcolor/exception/GlobalExceptionHandler.java
@@ -42,6 +42,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return createResponseEntity(errorCode);
     }
 
+    @ExceptionHandler(PyonsnalcolorProductException.class)
+    public ResponseEntity<Object> handleProductException(PyonsnalcolorProductException e) {
+        log.error("GlobalExceptionHandler catch PyonsnalcolorProductException: {}", e.getErrorCode().name());
+        ErrorCode errorCode = e.getErrorCode();
+        return createResponseEntity(errorCode);
+    }
+
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<Object> handleNoSuchElementException(PyonsnalcolorPushException e) {
         log.error("GlobalExceptionHandler catch NoSuchElementException: {}", e.getErrorCode().name());

--- a/src/main/java/com/pyonsnalcolor/exception/PyonsnalcolorProductException.java
+++ b/src/main/java/com/pyonsnalcolor/exception/PyonsnalcolorProductException.java
@@ -1,0 +1,10 @@
+package com.pyonsnalcolor.exception;
+
+import com.pyonsnalcolor.exception.model.ErrorCode;
+
+public class PyonsnalcolorProductException extends PyonsnalcolorException {
+
+    public PyonsnalcolorProductException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/pyonsnalcolor/exception/model/CommonErrorCode.java
+++ b/src/main/java/com/pyonsnalcolor/exception/model/CommonErrorCode.java
@@ -12,6 +12,7 @@ public enum CommonErrorCode implements ErrorCode {
 
     SERVER_UNAVAILABLE(SERVICE_UNAVAILABLE, "서버에 오류가 발생하였습니다."),
     INVALID_PARAMETER(BAD_REQUEST, "입력값이 형식에 맞지 않습니다."),
+    INVALID_FILTER_CODE(BAD_REQUEST, "필터 코드값이 유효하지 않습니다."),
     NOT_FOUND_ERROR(NOT_FOUND, "입력값이 형식에 맞지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/pyonsnalcolor/product/controller/EventProductController.java
+++ b/src/main/java/com/pyonsnalcolor/product/controller/EventProductController.java
@@ -1,6 +1,7 @@
 package com.pyonsnalcolor.product.controller;
 
 import com.pyonsnalcolor.product.dto.EventProductResponseDto;
+import com.pyonsnalcolor.product.dto.ProductFilterRequestDto;
 import com.pyonsnalcolor.product.dto.ProductResponseDto;
 import com.pyonsnalcolor.product.service.EventProductService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "이벤트 상품 api")
 @RestController
@@ -21,7 +19,8 @@ public class EventProductController {
 
     private final EventProductService eventProductService;
 
-    @Operation(summary = "이벤트 상품 조회", description = "이벤트 상품을 조회합니다.")
+    // TODO: v2 필터 조회 api 연동 후 삭제
+    @Operation(summary = "v1. 이벤트 상품 조회", description = "이벤트 상품을 조회합니다.")
     @GetMapping("/products/event-products")
     public ResponseEntity<Page<EventProductResponseDto>> getEventProducts(
             @RequestParam int pageNumber,
@@ -30,14 +29,27 @@ public class EventProductController {
             @RequestParam(defaultValue = "updatedTime") String sorted
     ) {
         Page<EventProductResponseDto> products = eventProductService
-                .getProductsWithPaging(pageNumber, pageSize, storeType, sorted);
+                .getProducts(pageNumber, pageSize, storeType, sorted);
         return new ResponseEntity(products, HttpStatus.OK);
     }
 
     @Operation(summary = "이벤트 상품 단건 조회", description = "id 바탕으로 이벤트 상품을 조회합니다.")
     @GetMapping("/products/event-products/{id}")
-    public ResponseEntity<ProductResponseDto> getEventProducts(@PathVariable String id) {
+    public ResponseEntity<EventProductResponseDto> getEventProduct(@PathVariable String id) {
         ProductResponseDto responseDto = eventProductService.getProduct(id);
         return new ResponseEntity(responseDto, HttpStatus.OK);
+    }
+
+    @Operation(summary = "v2. 이벤트 상품 필터 조회", description = "이벤트 상품을 필터링 조회합니다.")
+    @PostMapping("/products/event-products")
+    public ResponseEntity<Page<EventProductResponseDto>> getEventProductsByFilter(
+            @RequestParam int pageNumber,
+            @RequestParam int pageSize,
+            @RequestParam(defaultValue = "all") String storeType,
+            @RequestBody ProductFilterRequestDto productFilterRequestDto
+    ) {
+        Page<ProductResponseDto> products = eventProductService.getFilteredProducts(
+                pageNumber, pageSize, storeType, productFilterRequestDto);
+        return new ResponseEntity(products, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/controller/PbProductController.java
+++ b/src/main/java/com/pyonsnalcolor/product/controller/PbProductController.java
@@ -1,6 +1,7 @@
 package com.pyonsnalcolor.product.controller;
 
 import com.pyonsnalcolor.product.dto.PbProductResponseDto;
+import com.pyonsnalcolor.product.dto.ProductFilterRequestDto;
 import com.pyonsnalcolor.product.dto.ProductResponseDto;
 import com.pyonsnalcolor.product.service.PbProductService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "PB 상품 api")
 @RestController
@@ -21,9 +19,10 @@ public class PbProductController {
 
     private final PbProductService pbProductService;
 
-    @Operation(summary = "PB 상품 조회", description = "PB 상품을 조회합니다.")
+    // TODO: v2 필터 조회 api 연동 후 삭제
+    @Operation(summary = "v1. PB 상품 조회", description = "PB 상품을 조회합니다.")
     @GetMapping("/products/pb-products")
-    public ResponseEntity<Page<ProductResponseDto>> getPbProducts(
+    public ResponseEntity<Page<PbProductResponseDto>> getPbProducts(
             @RequestParam int pageNumber,
             @RequestParam int pageSize,
             @RequestParam(defaultValue = "all") String storeType,
@@ -36,8 +35,21 @@ public class PbProductController {
 
     @Operation(summary = "PB 상품 단건 조회", description = "id 바탕으로 PB 상품을 조회합니다.")
     @GetMapping("/products/pb-products/{id}")
-    public ResponseEntity<ProductResponseDto> getPbProducts(@PathVariable String id) {
+    public ResponseEntity<PbProductResponseDto> getPbProducts(@PathVariable String id) {
         ProductResponseDto product = pbProductService.getProduct(id);
         return new ResponseEntity(product, HttpStatus.OK);
+    }
+
+    @Operation(summary = "v2. PB 상품 필터 조회", description = "PB 상품을 필터링 조회합니다.")
+    @PostMapping("/products/pb-products")
+    public ResponseEntity<Page<PbProductResponseDto>> getPbProductsByFilter(
+            @RequestParam int pageNumber,
+            @RequestParam int pageSize,
+            @RequestParam(defaultValue = "all") String storeType,
+            @RequestBody ProductFilterRequestDto productFilterRequestDto
+    ) {
+        Page<ProductResponseDto> products =  pbProductService.getFilteredProducts(
+                pageNumber, pageSize, storeType, productFilterRequestDto);
+        return new ResponseEntity(products, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/controller/ProductController.java
+++ b/src/main/java/com/pyonsnalcolor/product/controller/ProductController.java
@@ -3,7 +3,7 @@ package com.pyonsnalcolor.product.controller;
 import com.pyonsnalcolor.product.metadata.FilterItems;
 import com.pyonsnalcolor.product.metadata.ProductMetaData;
 import com.pyonsnalcolor.product.dto.ProductResponseDto;
-import com.pyonsnalcolor.product.service.ProductService;
+import com.pyonsnalcolor.product.service.SearchProduct;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,7 +21,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ProductController {
 
-    private final ProductService productService;
+    private final SearchProduct searchProduct;
 
     @Operation(summary = "상품 검색", description = "전체 상품 중에 해당 키워드가 포함된 상품을 조회합니다.")
     @GetMapping("/products/search")
@@ -30,7 +30,7 @@ public class ProductController {
             @RequestParam int pageSize,
             @RequestParam String name
     ) {
-        Page<ProductResponseDto> products = productService.searchProduct(pageNumber, pageSize, name);
+        Page<ProductResponseDto> products = searchProduct.searchProduct(pageNumber, pageSize, name);
         return new ResponseEntity(products, HttpStatus.OK);
     }
 
@@ -38,7 +38,7 @@ public class ProductController {
     @GetMapping("/products/meta-data")
     public ResponseEntity<Map<String, List<FilterItems>>> getProductMetaData() {
         ProductMetaData productMetaData = ProductMetaData.getInstance();
-        Map<String, List<FilterItems>> productMetaDataMetadataList = productMetaData.getMetadataList();
-        return new ResponseEntity(productMetaDataMetadataList, HttpStatus.OK);
+        Map<String, List<FilterItems>> result = productMetaData.getMetadata();
+        return new ResponseEntity(result, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/dto/EventProductResponseDto.java
+++ b/src/main/java/com/pyonsnalcolor/product/dto/EventProductResponseDto.java
@@ -1,13 +1,10 @@
 package com.pyonsnalcolor.product.dto;
 
-import com.pyonsnalcolor.product.enumtype.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-
-import javax.validation.constraints.NotBlank;
 
 @Schema(description = "이벤트 상품 조회 Response DTO")
 @SuperBuilder
@@ -15,8 +12,6 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @NoArgsConstructor
 public class EventProductResponseDto extends ProductResponseDto {
-    @NotBlank
-    private EventType eventType;
     private String originPrice;
     private String giftImage;
     private String giftTitle;

--- a/src/main/java/com/pyonsnalcolor/product/dto/PbProductResponseDto.java
+++ b/src/main/java/com/pyonsnalcolor/product/dto/PbProductResponseDto.java
@@ -6,10 +6,11 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
-@Schema(description = "Pb 상품 조회 Response DTO")
+@Schema(description = "PB 상품 조회 Response DTO")
 @SuperBuilder
 @ToString(callSuper = true)
 @Getter
 @NoArgsConstructor
 public class PbProductResponseDto extends ProductResponseDto {
+    private String recommend;
 }

--- a/src/main/java/com/pyonsnalcolor/product/dto/ProductFilterRequestDto.java
+++ b/src/main/java/com/pyonsnalcolor/product/dto/ProductFilterRequestDto.java
@@ -1,0 +1,12 @@
+package com.pyonsnalcolor.product.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ProductFilterRequestDto {
+    private List<Integer> filterList;
+}

--- a/src/main/java/com/pyonsnalcolor/product/dto/ProductResponseDto.java
+++ b/src/main/java/com/pyonsnalcolor/product/dto/ProductResponseDto.java
@@ -5,11 +5,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import com.pyonsnalcolor.product.enumtype.Category;
 import com.pyonsnalcolor.product.enumtype.EventType;
-import com.pyonsnalcolor.product.enumtype.Recommend;
 import com.pyonsnalcolor.product.enumtype.StoreType;
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -19,7 +17,6 @@ import lombok.experimental.SuperBuilder;
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 
-@Schema(description = "상품 조회 Response DTO")
 @SuperBuilder
 @ToString
 @Getter
@@ -45,9 +42,6 @@ public class ProductResponseDto {
     private LocalDateTime updatedTime;
     private String description;
     @NotBlank
-    private Boolean isNew = false;
-    @NotBlank
-    private Category category;
-    @NotBlank
-    private Recommend recommend;
+    private Boolean isNew;
+    private String category;
 }

--- a/src/main/java/com/pyonsnalcolor/product/entity/BaseEventProduct.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BaseEventProduct.java
@@ -1,7 +1,6 @@
 package com.pyonsnalcolor.product.entity;
 
 import com.pyonsnalcolor.product.dto.EventProductResponseDto;
-import com.pyonsnalcolor.product.enumtype.EventType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -31,8 +30,7 @@ public class BaseEventProduct extends BaseProduct {
                 .price(getPrice())
                 .updatedTime(getUpdatedTime())
                 .eventType(getEventType())
-                .category(getCategory())
-                .recommend(getRecommend())
+                .category((getCategory() == null) ? null : getCategory().getKorean())
                 .originPrice(getOriginPrice())
                 .giftImage(getGiftImage())
                 .giftPrice(getGiftPrice())

--- a/src/main/java/com/pyonsnalcolor/product/entity/BaseEventProduct.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BaseEventProduct.java
@@ -35,7 +35,7 @@ public class BaseEventProduct extends BaseProduct {
                 .giftImage(getGiftImage())
                 .giftPrice(getGiftPrice())
                 .giftTitle(getGiftTitle())
-                .isNew(true)
+                .isNew(getIsNew())
                 .build();
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/entity/BasePbProduct.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BasePbProduct.java
@@ -1,6 +1,7 @@
 package com.pyonsnalcolor.product.entity;
 
 import com.pyonsnalcolor.product.dto.PbProductResponseDto;
+import com.pyonsnalcolor.product.enumtype.Recommend;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -13,6 +14,8 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @Document(collection = "pb_product")
 public class BasePbProduct extends BaseProduct {
+    private Recommend recommend;
+
     @Override
     public PbProductResponseDto convertToDto() {
         return PbProductResponseDto.builder()
@@ -24,9 +27,17 @@ public class BasePbProduct extends BaseProduct {
                 .price(getPrice())
                 .eventType(getEventType())
                 .updatedTime(getUpdatedTime())
-                .category(getCategory())
-                .recommend(getRecommend())
-                .isNew(true)
+                .category((getCategory() == null) ? null : getCategory().getKorean())
+                .recommend((getRecommend() == null) ? null : getRecommend().getKorean())
+                .isNew(getIsNew())
                 .build();
+    }
+
+    public void updateRecommend(Recommend recommend) {
+        this.recommend = recommend;
+    }
+
+    public void deleteRecommend() {
+        this.recommend = null;
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
@@ -3,7 +3,6 @@ package com.pyonsnalcolor.product.entity;
 import com.pyonsnalcolor.product.dto.ProductResponseDto;
 import com.pyonsnalcolor.product.enumtype.Category;
 import com.pyonsnalcolor.product.enumtype.EventType;
-import com.pyonsnalcolor.product.enumtype.Recommend;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +12,7 @@ import org.springframework.data.mongodb.core.index.Indexed;
 
 import javax.persistence.Id;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 
 @SuperBuilder
 @ToString
@@ -27,12 +27,12 @@ public class BaseProduct {
     @Indexed
     private String name;
     private String price;
+    private int priceInt;
     private LocalDateTime updatedTime;
     private String description;
     private Category category;
-    private Recommend recommend;
-    private EventType eventType; // TODO: 이후 추가
-    private boolean isNew; // TODO: 이후 추가
+    private EventType eventType;
+    private Boolean isNew;
 
     public ProductResponseDto convertToDto() {
         return ProductResponseDto.builder()
@@ -44,8 +44,16 @@ public class BaseProduct {
                 .price(price)
                 .updatedTime(updatedTime)
                 .isNew(isNew)
-                .category(category)
-                .recommend(recommend)
+                .category((category == null) ? null : category.getKorean())
                 .build();
+    }
+
+    public void updateIsNew(boolean isNew) {
+        this.isNew = isNew;
+    }
+
+
+    public static Comparator<BaseProduct> getCategoryComparator() {
+        return Comparator.comparing(p -> Category.GOODS.equals(p.getCategory()));
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/enumtype/Category.java
+++ b/src/main/java/com/pyonsnalcolor/product/enumtype/Category.java
@@ -1,16 +1,11 @@
 package com.pyonsnalcolor.product.enumtype;
 
-import com.pyonsnalcolor.product.metadata.FilterItems;
-import com.pyonsnalcolor.product.metadata.FilterItem;
 import lombok.Getter;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.*;
 
 @Getter
-public enum Category {
+public enum Category implements Filter {
 
     GOODS(1001, "생활용품", Arrays.asList("세제", "샴푸", "린스", "페브리즈", "좋은", "치약", "칫솔", "극세모",
             "미세모", "클렌징폼", "면도", "대형", "중형", "소형", "실내", "클렌징", "오일", "피죤", "유기농", "로션",
@@ -48,44 +43,14 @@ public enum Category {
     private final String korean;
     private final List<String> keywords;
 
-    public static FilterItems categoryMetaData = new FilterItems("category", getCategoryMetaData());
-
     Category(int code, String korean, List<String> keywords) {
         this.code = code;
         this.korean = korean;
         this.keywords = keywords;
     }
 
-    public static Category matchCategoryByProductName(String name) {
-        return Arrays.stream(values())
-                .filter(category -> category.getKeywords()
-                        .stream()
-                        .anyMatch(name::contains))
-                .findFirst()
-                .orElse(null);
-    }
-
-    private static List<FilterItem> getCategoryMetaData() {
-        return Arrays.stream(values())
-                .map(category -> FilterItem.builder()
-                        .name(category.korean)
-                        .code(category.code)
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    public static List<Category> findCategoryByFilterList(String filterList) {
-        return Arrays.stream(filterList.split(","))
-                .map(Integer::parseInt)
-                .map(Category::matchCategoryByCode)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-    }
-
-    private static Category matchCategoryByCode(int code) {
-        return Arrays.stream(values())
-                .filter(c -> c.code == code)
-                .findFirst()
-                .orElse(null);
+    @Override
+    public String getFilterType() {
+        return this.getDeclaringClass().getSimpleName().toLowerCase();
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/enumtype/EventType.java
+++ b/src/main/java/com/pyonsnalcolor/product/enumtype/EventType.java
@@ -1,52 +1,37 @@
 package com.pyonsnalcolor.product.enumtype;
 
-import com.pyonsnalcolor.product.metadata.FilterItems;
-import com.pyonsnalcolor.product.metadata.FilterItem;
 import lombok.Getter;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Getter
-public enum EventType {
+public enum EventType implements Filter {
     ONE_TO_ONE(10001),
     TWO_TO_ONE(10002),
-    THREE_TO_ONE(10003),
-    GIFT(10004),
-    DISCOUNT(10005),
-    NONE(10006);
+    GIFT(10003),
+    DISCOUNT(10004),
+    NONE(10005);
 
     private final int code;
 
-    public static FilterItems eventTypeMetaData = new FilterItems("event", getEventMetaData());
+    private static final String FILTER_TYPE = "event";
 
     EventType(int code) {
         this.code = code;
     }
 
-    private static List<FilterItem> getEventMetaData() {
-        return Arrays.stream(values())
-                .map(event -> FilterItem.builder()
-                        .name(event.name())
-                        .code(event.code)
-                        .build())
-                .collect(Collectors.toList());
+    @Override
+    public String getKorean() {
+        return name();
     }
 
-    public static List<EventType> findEventTypeByFilterList(String filterList) {
-        return Arrays.stream(filterList.split(","))
-                .map(Integer::parseInt)
-                .map(EventType::matchEventTypeByCode)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+    @Override
+    public String getFilterType() {
+        return FILTER_TYPE;
     }
 
-    private static EventType matchEventTypeByCode(int code) {
-        return Arrays.stream(values())
-                .filter(e -> e.code == code)
-                .findFirst()
-                .orElse(null);
+    @Override
+    public List<String> getKeywords() {
+        return null; // 필요X
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/enumtype/Filter.java
+++ b/src/main/java/com/pyonsnalcolor/product/enumtype/Filter.java
@@ -1,0 +1,71 @@
+package com.pyonsnalcolor.product.enumtype;
+
+import com.pyonsnalcolor.product.metadata.FilterItem;
+import com.pyonsnalcolor.product.metadata.FilterItems;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public interface Filter {
+
+    int getCode();
+
+    String getKorean();
+
+    String getFilterType();
+
+    List<String> getKeywords();
+
+    static Criteria getCriteria(List<? extends Filter> filters, String field, Criteria criteria) {
+        if (!filters.isEmpty()) {
+            return criteria.and(field).in(filters);
+        }
+        return  criteria;
+    }
+
+    static <T extends Filter> List<T> findEnumByFilterList(Class<T> enumClass, List<Integer> filterList) {
+        return filterList.stream()
+                .map(code -> matchEnumByCode(enumClass, code))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    static <T extends Filter> T matchEnumByCode(Class<T> enumClass, int code) {
+        return Arrays.stream(enumClass.getEnumConstants())
+                .filter(e -> e.getCode() == code)
+                .findFirst()
+                .orElse(null);
+    }
+
+    static <T extends Filter> List<FilterItem> getFilterItem(Class<T> enumClass) {
+        return Arrays.stream(enumClass.getEnumConstants())
+                .map(filter -> FilterItem.builder()
+                        .name(filter.getKorean())
+                        .code(filter.getCode())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    static <T extends Filter> FilterItems getMetaData(Class<T> enumClass) {
+        String filterType = enumClass.getEnumConstants()[0].getFilterType();
+        return new FilterItems(filterType, getFilterItem(enumClass));
+    }
+
+    static <T extends Filter> T matchEnumTypeByProductName(Class<T> enumClass, String productName) {
+        return Arrays.stream(enumClass.getEnumConstants())
+                .filter(filter -> filter.getKeywords()
+                        .stream()
+                        .anyMatch(productName::contains))
+                .findFirst()
+                .orElse(null);
+    }
+
+    static <T extends Filter> List<Integer> getCodes(Class<T> enumClass) {
+        return Arrays.stream(enumClass.getEnumConstants())
+                .map(Filter::getCode)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/src/main/java/com/pyonsnalcolor/product/enumtype/Recommend.java
+++ b/src/main/java/com/pyonsnalcolor/product/enumtype/Recommend.java
@@ -1,16 +1,12 @@
 package com.pyonsnalcolor.product.enumtype;
 
-import com.pyonsnalcolor.product.metadata.FilterItems;
-import com.pyonsnalcolor.product.metadata.FilterItem;
 import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Getter
-public enum Recommend {
+public enum Recommend implements Filter {
 
     NIGHT_WORK(101, "밤샘", Arrays.asList("비타", "과일", "액티비아", "에너지", "종근당", "인삼", "홍삼",
             "보약", "카페인", "녹차", "커피", "껌", "아메")),
@@ -21,10 +17,10 @@ public enum Recommend {
             "할라피뇨", "떡볶이", "라볶이", "얼큰", "하바네로", "멕시칸", "스파이시")),
     DRINK_SNACK(105, "간식", Arrays.asList("스낵", "김부각", "어묵바", "오징어", "젤리", "소시지", "땅콩", "믹스넛",
             "후랑크", "아몬드", "안주", "오뎅", "치즈", "육포", "말랭이", "감자")),
-    SWEET(106, "달달", Arrays.asList("스위트", "요거트", "버터", "카이막", "초코", "초콜릿", "쇼콜라", "키세스", "허쉬", "킷캣", "쿠앤크", "팥",
-            "바닐라", "허니", "빙수", "젤리", "달콤", "캐러멜", "모찌", "딸기", "바나나", "꿀")),
+    SWEET(106, "달달", Arrays.asList("스위트", "요거트", "버터", "카이막", "초코", "초콜릿", "쇼콜라", "키세스",
+            "허쉬", "킷캣", "쿠앤크", "팥", "바닐라", "허니", "빙수", "젤리", "달콤", "캐러멜", "모찌", "딸기", "바나나", "꿀")),
     ALONE(107, "혼밥", Arrays.asList("김밥", "컵밥", "큰컵")),
-    POPULAR(108, "인기있는", Arrays.asList());
+    HOT_ITEM(108, "인기있는", Arrays.asList());
     // TODO: 이후에 추가될 항목들
     // MIDNIGHT_SNACK(code, "야식", Arrays.asList("닭발", "후랑크", "버거", "라면", "샌드위치", "치킨", "피자")),
     // HANGOVER(code, "해장", Arrays.asList("헛개", "수프", "국", "우동", "오뎅", "호빵", "북엇국", "시원", "칼칼")),
@@ -36,44 +32,14 @@ public enum Recommend {
     private final String korean;
     private final List<String> keywords;
 
-    public static FilterItems recommendMetaData = new FilterItems("recommend", getRecommendMetaData());
-
     Recommend(int code, String korean, List<String> keywords) {
         this.code = code;
         this.korean = korean;
         this.keywords = keywords;
     }
 
-    public static Recommend matchRecommendByProductName(String name) {
-        return Arrays.stream(values())
-                .filter(recommend -> recommend.getKeywords()
-                        .stream()
-                        .anyMatch(name::contains))
-                .findFirst()
-                .orElse(null);
-    }
-
-    private static List<FilterItem> getRecommendMetaData() {
-        return Arrays.stream(values())
-                .map(tag -> FilterItem.builder()
-                        .name(tag.korean)
-                        .code(tag.code)
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    public static List<Recommend> findRecommendByFilterList(String filterList) {
-        return Arrays.stream(filterList.split(","))
-                .map(Integer::parseInt)
-                .map(Recommend::matchRecommendByCode)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-    }
-
-    private static Recommend matchRecommendByCode(int code) {
-        return Arrays.stream(values())
-                .filter(t -> t.code == code)
-                .findFirst()
-                .orElse(null);
+    @Override
+    public String getFilterType() {
+        return this.getDeclaringClass().getSimpleName().toLowerCase();
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/enumtype/Sorted.java
+++ b/src/main/java/com/pyonsnalcolor/product/enumtype/Sorted.java
@@ -1,42 +1,49 @@
 package com.pyonsnalcolor.product.enumtype;
 
-import com.pyonsnalcolor.product.metadata.FilterItems;
-import com.pyonsnalcolor.product.metadata.FilterItem;
+import com.pyonsnalcolor.product.entity.BaseProduct;
 import lombok.Getter;
 import org.springframework.data.domain.Sort;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Getter
-public enum Sorted {
-    LATEST(1, "최신순", Sort.by("updatedTime").descending().and(Sort.by("id"))),
-    VIEW(2, "조회순", Sort.by("updatedTime").descending().and(Sort.by("id"))),  // TODO: 이후 추가
-    LOW_PRICE(3, "가격낮은순", Sort.by("price").ascending().descending().and(Sort.by("id"))),
-    HIGH_PRICE(4, "가격높은순", Sort.by("price").descending().descending().and(Sort.by("id"))),
-    REVIEW(5, "리뷰순", Sort.by("updatedTime").descending().and(Sort.by("id"))); // TODO: 이후 추가
+public enum Sorted implements Filter {
+    LATEST(1,
+            "최신순",
+            Sort.by("updatedTime").descending().and(Sort.by("id")),
+            Comparator.comparing(BaseProduct::getUpdatedTime).reversed().thenComparing(BaseProduct::getId)),
+    VIEW(2,
+            "조회순",
+            Sort.by("id"),
+            Comparator.comparing(BaseProduct::getId)),  // TODO: 이후 추가
+    LOW_PRICE(3,
+            "가격낮은순",
+            Sort.by("priceInt").ascending().and(Sort.by("id")),
+            Comparator.comparing(BaseProduct::getPriceInt).thenComparing(BaseProduct::getId)),
+    HIGH_PRICE(4,
+            "가격높은순",
+            Sort.by("priceInt").descending().and(Sort.by("id")),
+            Comparator.comparing(BaseProduct::getPriceInt).reversed().thenComparing(BaseProduct::getId)),
+    REVIEW(5,
+            "리뷰순",
+            Sort.by("id"),
+            Comparator.comparing(BaseProduct::getId)); // TODO: 이후 추가
 
     private final int code;
     private final String korean;
     private final Sort sort;
+    private final Comparator<BaseProduct> comparator;
 
-    public static FilterItems sortedMetaData = new FilterItems("sort", getSortedMetaData());
+    private static final String FILTER_TYPE = "sort";
 
-    Sorted(int code, String korean, Sort sort) {
+    Sorted(int code, String korean, Sort sort, Comparator<BaseProduct> comparator) {
         this.code = code;
         this.korean = korean;
         this.sort = sort;
-    }
-
-    private static List<FilterItem> getSortedMetaData() {
-        return Arrays.stream(values())
-                .map(sorted -> FilterItem.builder()
-                        .name(sorted.korean)
-                        .code(sorted.code)
-                        .build())
-                .collect(Collectors.toList());
+        this.comparator = comparator;
     }
 
     public static Sort findSortedByFilterList(String filterList) {
@@ -54,5 +61,34 @@ public enum Sorted {
                 .filter(t -> t.code == code)
                 .findFirst()
                 .orElse(null);
+    }
+
+    public static Comparator<BaseProduct> getCategoryFilteredComparator(List<Integer> filterList) {
+        Comparator<BaseProduct> filter = Sorted.findComparatorByFilterList(filterList);
+
+        if (Sorted.LATEST.getComparator() == filter) {
+            return BaseProduct.getCategoryComparator()
+                    .thenComparing(filter);
+        }
+        return filter;
+    }
+
+    private static Comparator<BaseProduct> findComparatorByFilterList(List<Integer> filterList) {
+        return filterList.stream()
+                .map(Sorted::matchSortedByCode)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(LATEST)
+                .getComparator();
+    }
+
+    @Override
+    public String getFilterType() {
+        return FILTER_TYPE;
+    }
+
+    @Override
+    public List<String> getKeywords() {
+        return null; // 필요X
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/enumtype/Sorted.java
+++ b/src/main/java/com/pyonsnalcolor/product/enumtype/Sorted.java
@@ -46,9 +46,8 @@ public enum Sorted implements Filter {
         this.comparator = comparator;
     }
 
-    public static Sort findSortedByFilterList(String filterList) {
-        return Arrays.stream(filterList.split(","))
-                .map(Integer::parseInt)
+    public static Sort findSortedByFilterList(List<Integer> filterList) {
+        return filterList.stream()
                 .map(Sorted::matchSortedByCode)
                 .filter(Objects::nonNull)
                 .findFirst()

--- a/src/main/java/com/pyonsnalcolor/product/enumtype/StoreType.java
+++ b/src/main/java/com/pyonsnalcolor/product/enumtype/StoreType.java
@@ -1,8 +1,29 @@
 package com.pyonsnalcolor.product.enumtype;
 
 import lombok.Getter;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.Arrays;
 
 @Getter
 public enum StoreType {
-    SEVEN_ELEVEN, CU, GS25, EMART24
+    SEVEN_ELEVEN, CU, GS25, EMART24, ALL;
+
+    public static final String FILTER_TYPE = "storeType";
+
+    public static StoreType getStoreType(String storeTypeStr) {
+        String storeTypeUppercase = storeTypeStr.toUpperCase();
+        return Arrays.stream(StoreType.values())
+                .filter(s -> s.name().equals(storeTypeUppercase))
+                .findFirst()
+                .orElseThrow(NoSuchFieldError::new);
+    }
+
+    public static Criteria getCriteria(String storeTypeStr, Criteria criteria) {
+        StoreType storeType = StoreType.getStoreType(storeTypeStr);
+        if (storeType == StoreType.ALL) {
+            return criteria;
+        }
+        return criteria.and(FILTER_TYPE).is(storeType);
+    }
 }

--- a/src/main/java/com/pyonsnalcolor/product/metadata/ProductMetaData.java
+++ b/src/main/java/com/pyonsnalcolor/product/metadata/ProductMetaData.java
@@ -1,9 +1,6 @@
 package com.pyonsnalcolor.product.metadata;
 
-import com.pyonsnalcolor.product.enumtype.Category;
-import com.pyonsnalcolor.product.enumtype.EventType;
-import com.pyonsnalcolor.product.enumtype.Recommend;
-import com.pyonsnalcolor.product.enumtype.Sorted;
+import com.pyonsnalcolor.product.enumtype.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -14,13 +11,15 @@ public class ProductMetaData {
     private static final String META_DATA_KEY = "data";
 
     private static ProductMetaData instance;
-    private List<FilterItems> metaDataList;
+    private final List<FilterItems> metaDataList;
 
     private ProductMetaData() {
-        metaDataList = List.of(Sorted.sortedMetaData,
-                        Recommend.recommendMetaData,
-                        Category.categoryMetaData,
-                        EventType.eventTypeMetaData);
+        metaDataList = List.of(
+                Filter.getMetaData(Sorted.class),
+                Filter.getMetaData(Recommend.class),
+                Filter.getMetaData(Category.class),
+                Filter.getMetaData(EventType.class)
+        );
     }
 
     public static ProductMetaData getInstance() {
@@ -30,7 +29,7 @@ public class ProductMetaData {
         return instance;
     }
 
-    public Map<String, List<FilterItems>> getMetadataList() {
+    public Map<String, List<FilterItems>> getMetadata() {
         return Collections.singletonMap(META_DATA_KEY, metaDataList);
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/repository/EventProductRepository.java
+++ b/src/main/java/com/pyonsnalcolor/product/repository/EventProductRepository.java
@@ -3,9 +3,7 @@ package com.pyonsnalcolor.product.repository;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
-public interface EventProductRepository extends BasicProductRepository<BaseEventProduct, String> {
-    Optional<BaseEventProduct> findByName(String name);
+public interface EventProductRepository
+        extends BasicProductRepository<BaseEventProduct, String> {
 }

--- a/src/main/java/com/pyonsnalcolor/product/service/EventProductService.java
+++ b/src/main/java/com/pyonsnalcolor/product/service/EventProductService.java
@@ -1,10 +1,12 @@
 package com.pyonsnalcolor.product.service;
 
+import com.pyonsnalcolor.exception.PyonsnalcolorProductException;
 import com.pyonsnalcolor.product.dto.EventProductResponseDto;
+import com.pyonsnalcolor.product.dto.ProductFilterRequestDto;
+import com.pyonsnalcolor.product.dto.ProductResponseDto;
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
-import com.pyonsnalcolor.product.enumtype.StoreType;
+import com.pyonsnalcolor.product.enumtype.*;
 import com.pyonsnalcolor.product.repository.EventProductRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -12,30 +14,38 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.pyonsnalcolor.exception.model.CommonErrorCode.INVALID_FILTER_CODE;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
-public class EventProductService {
-    private final EventProductRepository eventProductRepository;
+public class EventProductService extends ProductService{
 
-    public Page<EventProductResponseDto> getProductsWithPaging(int pageNumber, int pageSize, String storeType, String sorted) {
+    public EventProductService(EventProductRepository eventProductRepository) {
+        super(eventProductRepository);
+    }
+
+    // TODO: v2 필터 조회 api 연동 후 삭제
+    public Page<EventProductResponseDto> getProducts(int pageNumber, int pageSize, String storeType, String sorted) {
 
         Sort sort = Sort.by("updatedTime").descending().and(Sort.by("id"));
         String storeTypeUppercase = storeType.toUpperCase();
         PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, sort);
 
         if (storeTypeUppercase.equals("ALL")) {
-            Page<BaseEventProduct> products = eventProductRepository.findAll(pageRequest);
+            Page<BaseEventProduct> products = basicProductRepository.findAll(pageRequest);
             return convertToEventProductResponseDto(products);
         }
         StoreType storeTypeEnum = StoreType.valueOf(storeTypeUppercase);
-        Page<BaseEventProduct> products = eventProductRepository.findByStoreType(storeTypeEnum, pageRequest);
+        Page<BaseEventProduct> products = basicProductRepository.findByStoreType(storeTypeEnum, pageRequest);
         return convertToEventProductResponseDto(products);
     }
 
+    // TODO: v2 필터 조회 api 연동 후 삭제
     private Page<EventProductResponseDto> convertToEventProductResponseDto(Page<BaseEventProduct> products) {
         List<EventProductResponseDto> productResponseDtos = products.getContent().stream()
                 .map(BaseEventProduct::convertToDto)
@@ -44,9 +54,32 @@ public class EventProductService {
         return new PageImpl<>(productResponseDtos, products.getPageable(), products.getTotalElements());
     }
 
-    public EventProductResponseDto getProduct(String id) {
-        return eventProductRepository.findById(id)
-                .map(BaseEventProduct::convertToDto)
-                .orElseThrow();
+    @Override
+    public Page<ProductResponseDto> getFilteredProducts(
+            int pageNumber, int pageSize, String storeType, ProductFilterRequestDto productFilterRequestDto
+    ) {
+        List<Integer> filterList = productFilterRequestDto.getFilterList();
+        validateProductFilterCodes(filterList);
+
+        List<BaseEventProduct> responseDtos = getProductsListByFilter(storeType, filterList, BaseEventProduct.class);
+        List<ProductResponseDto> result = convertToResponseDtoList(responseDtos);
+
+        Sort sort = Sorted.findSortedByFilterList(filterList);
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, sort);
+        return convertToPage(result, pageRequest);
+    }
+
+    @Override
+    protected void validateProductFilterCodes(List<Integer> filterList) {
+        List<Integer> codes = Stream.of(
+                Filter.getCodes(Category.class),
+                Filter.getCodes(Sorted.class),
+                Filter.getCodes(EventType.class))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        if (!codes.containsAll(filterList)) {
+            throw new PyonsnalcolorProductException(INVALID_FILTER_CODE);
+        }
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/service/PbProductService.java
+++ b/src/main/java/com/pyonsnalcolor/product/service/PbProductService.java
@@ -1,31 +1,31 @@
 package com.pyonsnalcolor.product.service;
 
+import com.pyonsnalcolor.exception.PyonsnalcolorProductException;
+import com.pyonsnalcolor.exception.model.CommonErrorCode;
 import com.pyonsnalcolor.product.dto.PbProductResponseDto;
+import com.pyonsnalcolor.product.dto.ProductFilterRequestDto;
 import com.pyonsnalcolor.product.dto.ProductResponseDto;
-import com.pyonsnalcolor.product.entity.BaseEventProduct;
 import com.pyonsnalcolor.product.entity.BasePbProduct;
-import com.pyonsnalcolor.product.enumtype.StoreType;
-import com.pyonsnalcolor.product.repository.EventProductRepository;
+import com.pyonsnalcolor.product.enumtype.*;
 import com.pyonsnalcolor.product.repository.PbProductRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
-@RequiredArgsConstructor
-public class PbProductService {
+public class PbProductService extends ProductService {
 
-    private final PbProductRepository pbProductRepository;
-    private final EventProductRepository eventProductRepository;
+    public PbProductService(PbProductRepository pbProductRepository) {
+        super(pbProductRepository);
+    }
 
+    // TODO: v2 필터 조회 api 연동 후 삭제
     public Page<PbProductResponseDto> getProductsWithPaging(int pageNumber, int pageSize, String storeType, String filterList) {
 
         Sort sort = Sort.by("updatedTime").descending().and(Sort.by("id"));
@@ -33,13 +33,16 @@ public class PbProductService {
         PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, sort);
 
         if (storeTypeUppercase.equals("ALL")) {
-            Page<BasePbProduct> products = pbProductRepository.findAll(pageRequest);
+            Page<BasePbProduct> products = basicProductRepository.findAll(pageRequest);
             return convertToPbProductResponseDto(products);
         }
         StoreType storeTypeEnum = StoreType.valueOf(storeTypeUppercase);
-        Page<BasePbProduct> products = pbProductRepository.findByStoreType(storeTypeEnum, pageRequest);
+        Page<BasePbProduct> products = basicProductRepository.findByStoreType(storeTypeEnum, pageRequest);
+
         return convertToPbProductResponseDto(products);
     }
+
+    // TODO: v2 필터 조회 api 연동 후 삭제
     private Page<PbProductResponseDto> convertToPbProductResponseDto(Page<BasePbProduct> products) {
         List<PbProductResponseDto> productResponseDtos = products.getContent().stream()
                 .map(BasePbProduct::convertToDto)
@@ -48,19 +51,34 @@ public class PbProductService {
         return new PageImpl<>(productResponseDtos, products.getPageable(), products.getTotalElements());
     }
 
-    public ProductResponseDto getProduct(String id) {
-        ProductResponseDto product = pbProductRepository.findById(id)
-                .map(BasePbProduct::convertToDto)
-                .orElseThrow(NoSuchElementException::new);
-        setEventType(product);
+    @Override
+    public Page<ProductResponseDto> getFilteredProducts(
+            int pageNumber, int pageSize, String storeType, ProductFilterRequestDto productFilterRequestDto
+    ) {
+        List<Integer> filterList = productFilterRequestDto.getFilterList();
+        validateProductFilterCodes(filterList);
 
-        return product;
+        Comparator comparator = Sorted.getCategoryFilteredComparator(filterList);
+        List<BasePbProduct> responseDtos = getProductsListByFilter(storeType, filterList, BasePbProduct.class);
+        responseDtos.sort(comparator);
+
+        List<ProductResponseDto> result = convertToResponseDtoList(responseDtos);
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize);
+        return convertToPage(result, pageRequest);
     }
 
-    public void setEventType(ProductResponseDto productResponseDto) {
-        Optional<BaseEventProduct> eventProduct = eventProductRepository.findByName(productResponseDto.getName());
-        if(eventProduct.isPresent()) {
-            productResponseDto.setEventType(eventProduct.get().getEventType());
+    @Override
+    protected void validateProductFilterCodes(List<Integer> filterList) {
+        List<Integer> codes = Stream.of(
+                Filter.getCodes(Category.class),
+                Filter.getCodes(Sorted.class),
+                Filter.getCodes(Recommend.class),
+                Filter.getCodes(EventType.class))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        if (!codes.containsAll(filterList)) {
+            throw new PyonsnalcolorProductException(CommonErrorCode.INVALID_FILTER_CODE);
         }
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/service/ProductService.java
+++ b/src/main/java/com/pyonsnalcolor/product/service/ProductService.java
@@ -1,69 +1,77 @@
 package com.pyonsnalcolor.product.service;
 
+import com.pyonsnalcolor.product.dto.ProductFilterRequestDto;
 import com.pyonsnalcolor.product.dto.ProductResponseDto;
-import com.pyonsnalcolor.product.entity.BaseEventProduct;
-import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.entity.BaseProduct;
-import com.pyonsnalcolor.product.repository.EventProductRepository;
-import com.pyonsnalcolor.product.repository.PbProductRepository;
+import com.pyonsnalcolor.product.enumtype.*;
+import com.pyonsnalcolor.product.repository.BasicProductRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.*;
-import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
-@Service
 @RequiredArgsConstructor
-public class ProductService {
+public abstract class ProductService {
+    protected final BasicProductRepository basicProductRepository;
 
-    private final EventProductRepository eventProductRepository;
-    private final PbProductRepository pbProductRepository;
+    @Autowired
+    private MongoTemplate mongoTemplate;
 
-    public Page<ProductResponseDto> searchProduct(int pageNumber, int pageSize, String keyword) {
-        String searchKeyword = removeSpecialCharacters(keyword);
-
-        List<BaseEventProduct> eventProducts = eventProductRepository.findByNameContaining(searchKeyword);
-        List<BasePbProduct> pbProducts = pbProductRepository.findByNameContaining(searchKeyword);
-
-        Sort sort = Sort.by("updatedTime").descending().and(Sort.by("id"));
-        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, sort);
-
-        List<BaseProduct> searchProducts = getProductsExceptDuplicate(eventProducts, pbProducts);
-        List<ProductResponseDto> productResponseDtos = convertToProductResponseDto(searchProducts);
-
-        return convertToPage(productResponseDtos, pageRequest);
+    public ProductResponseDto getProduct(String id) {
+        Optional<BaseProduct> baseProduct = basicProductRepository.findById(id);
+        baseProduct.orElseThrow(NoSuchElementException::new);
+        return baseProduct.get().convertToDto();
     }
 
-    private String removeSpecialCharacters(String searchKeyword) {
-        String refinedKeyword = searchKeyword.replaceAll("[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]", "");
-        return refinedKeyword;
-    }
-
-    private List<BaseProduct> getProductsExceptDuplicate(
-            List<BaseEventProduct> eventProducts,
-            List<BasePbProduct> pbProducts
-    ) {
-        List<BaseProduct> products = eventProducts.stream()
-                .filter(event -> pbProducts.stream()
-                        .noneMatch(pb -> event.getName().equals(pb.getName())))
-                .collect(Collectors.toList());
-        products.addAll(pbProducts);
-        return products;
-    }
-
-    private List<ProductResponseDto> convertToProductResponseDto(List<BaseProduct> searchProducts) {
-        List<ProductResponseDto> responseDtos = searchProducts.stream()
+    protected List<ProductResponseDto> convertToResponseDtoList(List<? extends BaseProduct> products) {
+        return products.stream()
                 .map(BaseProduct::convertToDto)
                 .collect(Collectors.toList());
-
-        return responseDtos;
     }
 
-    private Page<ProductResponseDto> convertToPage(List<ProductResponseDto> dtos, PageRequest pageRequest) {
-        int start = (int) pageRequest.getOffset();
-        int end = Math.min((start + pageRequest.getPageSize()), dtos.size());
+    protected abstract Page<ProductResponseDto> getFilteredProducts(
+            int pageNumber, int pageSize, String storeType, ProductFilterRequestDto productFilterRequestDto);
 
-        return new PageImpl<>(dtos.subList(start, end), pageRequest, dtos.size());
+    protected abstract void validateProductFilterCodes(List<Integer> filterList);
+
+    protected Page<ProductResponseDto> convertToPage(List<ProductResponseDto> list, PageRequest pageRequest) {
+        int start = (int) pageRequest.getOffset();
+        int end = Math.min((start + pageRequest.getPageSize()), list.size());
+
+        return new PageImpl<>(list.subList(start, end), pageRequest, list.size());
+    }
+
+    protected <T extends BaseProduct> List<T> getProductsListByFilter(
+            String storeType, List<Integer> filterList, Class<T> productClass
+    ) {
+        Query query = createQueryByFilter(storeType, filterList);
+        return mongoTemplate.find(query, productClass);
+    }
+
+    private Query createQueryByFilter(String storeType, List<Integer> filterList) {
+        List<Recommend> recommends = Filter.findEnumByFilterList(Recommend.class, filterList);
+        List<Category> categories = Filter.findEnumByFilterList(Category.class, filterList);
+        List<EventType> eventTypes = Filter.findEnumByFilterList(EventType.class, filterList);
+
+        Criteria criteria = createFilterCriteria(recommends, categories, eventTypes, storeType);
+        return new Query(criteria);
+    }
+
+    private Criteria createFilterCriteria(List<Recommend> recommends, List<Category> categories,
+                                          List<EventType> eventTypes, String storeType) {
+        Criteria criteria = new Criteria();
+        criteria = Filter.getCriteria(recommends, "recommend", criteria);
+        criteria = Filter.getCriteria(categories, "category", criteria);
+        criteria = Filter.getCriteria(eventTypes, "eventType", criteria);
+        criteria = StoreType.getCriteria(storeType, criteria);
+
+        return criteria;
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/service/SearchProduct.java
+++ b/src/main/java/com/pyonsnalcolor/product/service/SearchProduct.java
@@ -1,0 +1,64 @@
+package com.pyonsnalcolor.product.service;
+
+import com.pyonsnalcolor.product.dto.*;
+import com.pyonsnalcolor.product.entity.BaseEventProduct;
+import com.pyonsnalcolor.product.entity.BasePbProduct;
+import com.pyonsnalcolor.product.entity.BaseProduct;
+import com.pyonsnalcolor.product.repository.EventProductRepository;
+import com.pyonsnalcolor.product.repository.PbProductRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class SearchProduct {
+    private final EventProductRepository eventProductRepository;
+    private final PbProductRepository pbProductRepository;
+
+    public Page<ProductResponseDto> searchProduct(int pageNumber, int pageSize, String searchKeyword) {
+        List<BaseEventProduct> eventProducts = eventProductRepository.findByNameContaining(searchKeyword);
+        List<BasePbProduct> pbProducts = pbProductRepository.findByNameContaining(searchKeyword);
+
+        Sort sort = Sort.by("updatedTime").descending().and(Sort.by("id"));
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, sort);
+
+        List<BaseProduct> searchProducts = getProductsExceptDuplicate(eventProducts, pbProducts);
+        List<ProductResponseDto> productResponseDtos = convertToProductResponseDto(searchProducts);
+
+        return convertToPage(productResponseDtos, pageRequest);
+    }
+
+    private List<BaseProduct> getProductsExceptDuplicate(
+            List<BaseEventProduct> eventProducts,
+            List<BasePbProduct> pbProducts
+    ) {
+        List<BaseProduct> products = eventProducts.stream()
+                .filter(event -> pbProducts.stream()
+                        .noneMatch(pb -> event.getName().equals(pb.getName())))
+                .collect(Collectors.toList());
+        products.addAll(pbProducts);
+        return products;
+    }
+
+    private List<ProductResponseDto> convertToProductResponseDto(List<BaseProduct> searchProducts) {
+        List<ProductResponseDto> responseDtos = searchProducts.stream()
+                .map(BaseProduct::convertToDto)
+                .collect(Collectors.toList());
+
+        return responseDtos;
+    }
+
+    private Page<ProductResponseDto> convertToPage(List<ProductResponseDto> list, PageRequest pageRequest) {
+        int start = (int) pageRequest.getOffset();
+        int end = Math.min((start + pageRequest.getPageSize()), list.size());
+
+        return new PageImpl<>(list.subList(start, end), pageRequest, list.size());
+    }
+}


### PR DESCRIPTION
### 구현 사항
- **PB, 행사 상품 정렬 조회 기능 구현** : 필터 코드로 필터링 항목 구분
  - 정렬(최신순, 가격높은순, 가격낮은순) -> 조회순, 리뷰순 이후 구현
  - 상품 추천 필터링 (PB만 해당, 이벤트는 X)
  - 카테고리 필터링
  - 이벤트 타입 필터링
- **PB 상품의 최신순 정렬 => category 중 GOODS(생활용품)은 최하단 정렬**
  - 이 로직때문에 PB는 Comparator로 정렬. (행사 상품은 Sort로 정렬)

### 참고 사항
- 편의점 PB, 행사 상품 정렬할 때 mongoTemplate 사용했습니다
- 없는 필터 코드값 요청 시의 예외 처리 추가했습니다

**☑ 개선 사항!**
   - [ ] 정렬 개선
   - [ ] PB/행사 상품별 고유 필터값 싱글톤 처리
   - [ ] Page -> Slice로 

![image](https://github.com/YAPP-Github/pyonsnalcolor-server/assets/77563814/7ea1139e-99c9-47a7-bafd-53f9af96ec71)
