### PR TITLE
Feature/fix batch PB 신상의 isNew, eventType 설정 로직 구현

### DIFF
--- a/src/main/java/com/pyonsnalcolor/batch/service/BasicBatchServiceTemplate.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/BasicBatchServiceTemplate.java
@@ -1,13 +1,13 @@
 package com.pyonsnalcolor.batch.service;
 
 import com.pyonsnalcolor.product.entity.BaseProduct;
-import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.product.repository.BasicProductRepository;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
+@Slf4j
 abstract class BasicBatchServiceTemplate<T extends BaseProduct> implements BatchService {
     protected BasicProductRepository basicProductRepository;
 
@@ -37,23 +37,8 @@ abstract class BasicBatchServiceTemplate<T extends BaseProduct> implements Batch
         return Collections.emptyList();
     }
 
-    private final List<T> getNewProducts(List<T> allProducts) {
-        if (allProducts.isEmpty()) {
-            return Collections.emptyList();
-        }
-        StoreType storeType = allProducts.get(0).getStoreType();
+    protected <T extends BaseProduct> List<T> getNewProducts(List<T> allProducts) { return Collections.emptyList();}
 
-        List<T> alreadyExistProducts = basicProductRepository.findByStoreType(storeType);
-        List<String> alreadyExistProductNames = alreadyExistProducts.stream()
-                .map(a -> a.getName())
-                .collect(Collectors.toList());
-
-        List<T> newProducts = allProducts.stream().filter(
-                p -> !alreadyExistProductNames.contains(p.getName())
-        ).collect(Collectors.toList());
-
-        return newProducts;
-    }
 
     // TODO : Alarm 서비스 완성 시 구현
     private final void sendAlarms(List<T> baseProducts) {

--- a/src/main/java/com/pyonsnalcolor/batch/service/EventBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/EventBatchService.java
@@ -2,16 +2,32 @@ package com.pyonsnalcolor.batch.service;
 
 
 import com.pyonsnalcolor.product.entity.BaseEventProduct;
+import com.pyonsnalcolor.product.entity.BaseProduct;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.product.repository.EventProductRepository;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 public abstract class EventBatchService extends BasicBatchServiceTemplate<BaseEventProduct> {
     public EventBatchService(EventProductRepository eventProductRepository) {
         super(eventProductRepository);
+    }
+
+    @Override
+    protected <T extends BaseProduct> List<T> getNewProducts(List<T> allProducts) {
+        if (allProducts.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<T> alreadyExistProducts = basicProductRepository.findAll();
+        List<T> newProducts = allProducts.stream()
+                .filter(product -> !alreadyExistProducts.contains(product))
+                .peek(product -> log.info("새로운 행사 상품이 저장됩니다. {}", product))
+                .collect(Collectors.toList());
+        return newProducts;
     }
 
     @Override

--- a/src/main/java/com/pyonsnalcolor/batch/service/PbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/PbBatchService.java
@@ -2,10 +2,43 @@ package com.pyonsnalcolor.batch.service;
 
 
 import com.pyonsnalcolor.product.entity.BasePbProduct;
+import com.pyonsnalcolor.product.entity.BaseProduct;
 import com.pyonsnalcolor.product.repository.PbProductRepository;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
 public abstract class PbBatchService extends BasicBatchServiceTemplate<BasePbProduct> {
     public PbBatchService(PbProductRepository pbProductRepository) {
         super(pbProductRepository);
+    }
+
+    @Override
+    protected final <T extends BaseProduct> List<T> getNewProducts(List<T> allProducts) {
+        if (allProducts.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<T> alreadyExistProducts = basicProductRepository.findAll();
+        updateIsNewOfAlreadyExistProducts(alreadyExistProducts);
+
+        List<T> newProducts = allProducts.stream()
+                .filter(product -> !alreadyExistProducts.contains(product))
+                .peek(product -> log.info("새로운 PB 상품이 저장됩니다. {}", product))
+                .peek(p -> p.updateIsNew(true))
+                .collect(Collectors.toList());
+        return newProducts;
+    }
+
+    private <T extends BaseProduct> void updateIsNewOfAlreadyExistProducts(List<T> alreadyExistProducts) {
+        alreadyExistProducts.stream()
+                .filter(T::getIsNew)
+                .forEach(product -> {
+                    product.updateIsNew(false);
+                    log.info("지난 주 PB 상품이 신상품에서 제외됩니다. {}", product);
+                    basicProductRepository.save(product);
+                });
     }
 }

--- a/src/main/java/com/pyonsnalcolor/batch/service/PbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/PbBatchService.java
@@ -1,10 +1,13 @@
 package com.pyonsnalcolor.batch.service;
 
 
+import com.pyonsnalcolor.product.entity.BaseEventProduct;
 import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.entity.BaseProduct;
+import com.pyonsnalcolor.product.repository.EventProductRepository;
 import com.pyonsnalcolor.product.repository.PbProductRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
 import java.util.List;
@@ -12,6 +15,10 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public abstract class PbBatchService extends BasicBatchServiceTemplate<BasePbProduct> {
+
+    @Autowired
+    private EventProductRepository eventProductRepository;
+
     public PbBatchService(PbProductRepository pbProductRepository) {
         super(pbProductRepository);
     }
@@ -21,6 +28,8 @@ public abstract class PbBatchService extends BasicBatchServiceTemplate<BasePbPro
         if (allProducts.isEmpty()) {
             return Collections.emptyList();
         }
+        updateEventTypeOfAllProducts(allProducts);
+
         List<T> alreadyExistProducts = basicProductRepository.findAll();
         updateIsNewOfAlreadyExistProducts(alreadyExistProducts);
 
@@ -39,6 +48,23 @@ public abstract class PbBatchService extends BasicBatchServiceTemplate<BasePbPro
                     product.updateIsNew(false);
                     log.info("지난 주 PB 상품이 신상품에서 제외됩니다. {}", product);
                     basicProductRepository.save(product);
+                });
+    }
+
+    private <T extends BaseProduct> void updateEventTypeOfAllProducts(List<T> alreadyExistProducts) {
+        List<BaseEventProduct> baseEventProducts = eventProductRepository.findAll();
+        alreadyExistProducts
+                .forEach(p -> updateEventTypeIfEventInProgress(p, baseEventProducts));
+    }
+
+    private void updateEventTypeIfEventInProgress(BaseProduct baseProduct, List<BaseEventProduct> baseEventProducts) {
+        baseEventProducts.stream()
+                .filter(baseEventProduct -> baseEventProduct.equals(baseProduct))
+                .findFirst()
+                .ifPresent(matchingEventProduct -> {
+                    baseProduct.updateEventType(matchingEventProduct.getEventType());
+                    basicProductRepository.save(baseProduct);
+                    log.info("PB 상품이 현재 {} 행사 진행 중입니다. {}", matchingEventProduct.getEventType(), baseProduct);
                 });
     }
 }

--- a/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/cu/CuEventBatchService.java
@@ -87,7 +87,7 @@ public class CuEventBatchService extends EventBatchService implements CuDescript
         String description = getDescription(element, "event");
         Category category = Filter.matchEnumTypeByProductName(Category.class, name);
 
-        BaseEventProduct baseEventProduct = BaseEventProduct.builder()
+        return BaseEventProduct.builder()
                 .id((generateId()))
                 .name(name)
                 .image(image)
@@ -97,8 +97,6 @@ public class CuEventBatchService extends EventBatchService implements CuDescript
                 .storeType(StoreType.CU)
                 .category(category)
                 .build();
-        log.info("CU {}", baseEventProduct.toString());
-        return baseEventProduct;
     }
 
     private String getCuEventUrlByPageIndex(int pageIndex) {

--- a/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPbBatchService.java
@@ -96,7 +96,7 @@ public class CuPbBatchService extends PbBatchService implements CuDescriptionBat
         Category category = Filter.matchEnumTypeByProductName(Category.class, name);
         Recommend recommend = Filter.matchEnumTypeByProductName(Recommend.class, name);
 
-        BasePbProduct basePbProduct =  BasePbProduct.builder()
+        return BasePbProduct.builder()
                 .id((generateId()))
                 .name(name)
                 .image(image)
@@ -106,8 +106,6 @@ public class CuPbBatchService extends PbBatchService implements CuDescriptionBat
                 .category(category)
                 .recommend(recommend)
                 .build();
-        log.info("CU {}", basePbProduct.toString());
-        return basePbProduct;
     }
 
     private String getCuPbUrlByPageIndexAndCategory(int pageIndex, String category) {

--- a/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24EventBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24EventBatchService.java
@@ -78,7 +78,7 @@ public class Emart24EventBatchService extends EventBatchService {
         String image = element.getElementsByTag("img").attr("src");
         Category category = Filter.matchEnumTypeByProductName(Category.class, name);
 
-        BaseEventProduct baseEventProduct = BaseEventProduct.builder()
+        return BaseEventProduct.builder()
                 .id(generateId())
                 .originPrice(parsedOriginPrice)
                 .storeType(StoreType.EMART24)
@@ -91,8 +91,6 @@ public class Emart24EventBatchService extends EventBatchService {
                 .name(name)
                 .category(category)
                 .build();
-        log.info("EMART24 {}", baseEventProduct.toString());
-        return baseEventProduct;
     }
 
     private String parseGiftImage(Element productElement) {

--- a/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PbBatchService.java
@@ -75,7 +75,7 @@ public class Emart24PbBatchService extends PbBatchService {
         Category category = Filter.matchEnumTypeByProductName(Category.class, name);
         Recommend recommend = Filter.matchEnumTypeByProductName(Recommend.class, name);
 
-        BasePbProduct basePbProduct = BasePbProduct.builder()
+        return BasePbProduct.builder()
                 .id(generateId())
                 .name(name)
                 .price(parsedPrice)
@@ -84,7 +84,5 @@ public class Emart24PbBatchService extends PbBatchService {
                 .category(category)
                 .recommend(recommend)
                 .build();
-        log.info("EMART24 {}", basePbProduct.toString());
-        return basePbProduct;
     }
 }

--- a/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25EventBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25EventBatchService.java
@@ -107,7 +107,7 @@ public class GS25EventBatchService extends EventBatchService {
         }
         Category category = Filter.matchEnumTypeByProductName(Category.class, name);
 
-        BaseEventProduct baseEventProduct = BaseEventProduct.builder()
+        return BaseEventProduct.builder()
                 .id(generateId())
                 .originPrice(null)
                 .storeType(StoreType.GS25)
@@ -120,8 +120,6 @@ public class GS25EventBatchService extends EventBatchService {
                 .name(name)
                 .category(category)
                 .build();
-        log.info("GS25 {}", baseEventProduct.toString());
-        return baseEventProduct;
     }
 
 

--- a/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25PbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/gs25/GS25PbBatchService.java
@@ -97,7 +97,7 @@ public class GS25PbBatchService extends PbBatchService {
         Category category = Filter.matchEnumTypeByProductName(Category.class, name);
         Recommend recommend = Filter.matchEnumTypeByProductName(Recommend.class, name);
 
-        BasePbProduct basePbProduct = BasePbProduct.builder()
+        return BasePbProduct.builder()
                 .id(generateId())
                 .name(name)
                 .price(parsedPrice)
@@ -106,8 +106,6 @@ public class GS25PbBatchService extends PbBatchService {
                 .category(category)
                 .recommend(recommend)
                 .build();
-        log.info("GS25 {}", basePbProduct.toString());
-        return basePbProduct;
     }
 
     private Map<String, Object> parsePaginationData(Object data) throws JsonProcessingException {

--- a/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventBatchService.java
@@ -67,7 +67,6 @@ public class SevenEventBatchService extends EventBatchService {
             String sevenEventUrl = getSevenEventUrlByPageIndexAndTab(pageIndex, tab);
             Document document = Jsoup.connect(sevenEventUrl).timeout(TIMEOUT).get();
             Elements elements = document.select(sevenEventTab.getDocumentTag());
-
             if (elements.isEmpty()) {
                 break;
             }

--- a/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenEventTab.java
@@ -87,7 +87,7 @@ public enum SevenEventTab {
         }
         Category category = Filter.matchEnumTypeByProductName(Category.class, name);
 
-        BaseEventProduct baseEventProduct = BaseEventProduct.builder()
+        return BaseEventProduct.builder()
                 .name(name)
                 .id(generateId())
                 .image(image)
@@ -100,8 +100,6 @@ public enum SevenEventTab {
                 .storeType(StoreType.SEVEN_ELEVEN)
                 .category(category)
                 .build();
-        log.info("세븐일레븐 {}", baseEventProduct.toString());
-        return baseEventProduct;
     }
 
     private List<BaseEventProduct> getPagedProductsByGift(Elements elements) {

--- a/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/seven/SevenPbBatchService.java
@@ -34,7 +34,7 @@ public class SevenPbBatchService extends PbBatchService {
     private static final String IMG_PREFIX = "https://www.7-eleven.co.kr";
     private static final String DOC_SELECT_TAG = "div.pic_product div.pic_product";
     private static final int PB_TAB = 5;
-    private static final int TIMEOUT = 5000;
+    private static final int TIMEOUT = 20000;
 
     public SevenPbBatchService(PbProductRepository pbProductRepository) {
         super(pbProductRepository);
@@ -86,7 +86,7 @@ public class SevenPbBatchService extends PbBatchService {
         Category category = Filter.matchEnumTypeByProductName(Category.class, name);
         Recommend recommend = Filter.matchEnumTypeByProductName(Recommend.class, name);
 
-        BasePbProduct basePbProduct = BasePbProduct.builder()
+        return BasePbProduct.builder()
                 .id(generateId())
                 .name(name)
                 .image(image)
@@ -95,8 +95,6 @@ public class SevenPbBatchService extends PbBatchService {
                 .category(category)
                 .recommend(recommend)
                 .build();
-        log.info("세븐일레븐 {}", basePbProduct.toString());
-        return basePbProduct;
     }
 
     private String getSevenPbUrlByPageIndex(int pageIndex) {

--- a/src/main/java/com/pyonsnalcolor/config/MongoDBConfig.java
+++ b/src/main/java/com/pyonsnalcolor/config/MongoDBConfig.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
@@ -27,7 +26,6 @@ public class MongoDBConfig {
     public MongoTemplate mongoTemplate() {
         return new MongoTemplate(mongoDatabaseFactory());
     }
-
 
     @Bean
     public AbstractMongoEventListener<Object> mongoEventListener() {

--- a/src/main/java/com/pyonsnalcolor/product/entity/BasePbProduct.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BasePbProduct.java
@@ -32,7 +32,7 @@ public class BasePbProduct extends BaseProduct {
                 .updatedTime(getCreatedDate())
                 .category((getCategory() == null) ? null : getCategory().getKorean())
                 .recommend((getRecommend() == null) ? null : getRecommend().getKorean())
-                .isNew(getIsNew())
+                .isNew(getIsNew() == null ? false : getIsNew())
                 .build();
     }
 

--- a/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
@@ -13,6 +13,7 @@ import org.springframework.data.mongodb.core.index.Indexed;
 import javax.persistence.Id;
 import java.text.NumberFormat;
 import java.util.Comparator;
+import java.util.Objects;
 
 @SuperBuilder
 @ToString
@@ -52,5 +53,18 @@ public abstract class BaseProduct extends BaseTimeEntity {
 
     public static Comparator<BaseProduct> getCategoryComparator() {
         return Comparator.comparing(p -> Category.GOODS.equals(p.getCategory()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof BaseProduct))
+            return false;
+        BaseProduct baseProduct = (BaseProduct) o;
+        return this.name.equals(baseProduct.name) && this.storeType == baseProduct.storeType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, storeType);
     }
 }

--- a/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BaseProduct.java
@@ -47,6 +47,10 @@ public abstract class BaseProduct extends BaseTimeEntity {
         this.isNew = isNew;
     }
 
+    public void updateEventType(EventType eventType) {
+        this.eventType = eventType;
+    }
+
     public String formattingPrice(int price) {
         return NumberFormat.getInstance().format(price);
     }

--- a/src/main/java/com/pyonsnalcolor/product/entity/BaseTimeEntity.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BaseTimeEntity.java
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import javax.persistence.Version;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/pyonsnalcolor/product/service/PbProductService.java
+++ b/src/main/java/com/pyonsnalcolor/product/service/PbProductService.java
@@ -28,7 +28,7 @@ public class PbProductService extends ProductService {
     // TODO: v2 필터 조회 api 연동 후 삭제
     public Page<PbProductResponseDto> getProductsWithPaging(int pageNumber, int pageSize, String storeType, String filterList) {
 
-        Sort sort = Sort.by("updatedTime").descending().and(Sort.by("id"));
+        Sort sort = Sort.by("createdDate").descending().and(Sort.by("id"));
         String storeTypeUppercase = storeType.toUpperCase();
         PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, sort);
 


### PR DESCRIPTION
### 구현 사항
다음 사항들을 전체 크롤링 시 반영하도록 변경
- **PB 신상의 isNew는 true로 업데이트**
- **지난주 PB 신상의 isNew는 false로 업데이트**
- **PB 신상이 현재 행사 상품일 경우 해당 eventType 저장**
- 행사 상품의 isNew 로직은 구현X, 0.0.2 배포 이후 isNew 삭제 예정
- 로그는 모든 상품마다 X, 신상품 혹은 PB 신상인데 행사 중일 경우만 출력하도록 변경


### 참고 사항
- #4 

- PB 신상일 경우의 로그
![image](https://github.com/YAPP-Github/pyonsnalcolor-server/assets/77563814/07698254-ef18-408c-bd96-eb45ac2c0c50)

- PB 상품이 행사 중일 경우의 로그
![image](https://github.com/YAPP-Github/pyonsnalcolor-server/assets/77563814/6f5bf459-ac2e-4352-9883-b52df136468b)

- 지난 주 PB 신상품의 isNew 는 false로
=> "지난 주 PB 상품이 신상품에서 제외됩니다. " + 상품 정보