### PR TITLE
Feature/fix batch promotion 프로모션(이벤트 페이지) 배치 로직 수정

### DIFF
--- a/src/main/java/com/pyonsnalcolor/batch/schedule/Scheduler.java
+++ b/src/main/java/com/pyonsnalcolor/batch/schedule/Scheduler.java
@@ -1,8 +1,6 @@
 package com.pyonsnalcolor.batch.schedule;
 
 import com.pyonsnalcolor.batch.service.BatchService;
-import com.pyonsnalcolor.batch.service.PromotionBatchService;
-import com.pyonsnalcolor.promotion.entity.Promotion;
 import org.springframework.scheduling.annotation.Scheduled;
 
 public abstract class Scheduler {
@@ -19,9 +17,13 @@ public abstract class Scheduler {
     }
 
     @Scheduled(cron = "0 0 6 * * SUN")
-    public void run() {
+    public void runProductBatch() {
         pbProductBatchService.execute();
         eventProductBatchService.execute();
+    }
+
+    @Scheduled(cron = "0 0 1 * * *")
+    public void runPromotionBatch() {
         promotionBatchService.execute();
     }
 }

--- a/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPromotionBatchService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/cu/CuPromotionBatchService.java
@@ -40,7 +40,7 @@ public class CuPromotionBatchService extends PromotionBatchService {
     }
 
     @Override
-    public List<Promotion> getAllPromotions() {
+    public List<Promotion> getNewPromotions() {
         try {
             return getPromotions();
         } catch (IllegalArgumentException e) {
@@ -70,6 +70,7 @@ public class CuPromotionBatchService extends PromotionBatchService {
 
             List<Promotion> pagedPromotions = elements.stream()
                     .map(this::convertToPromotion)
+                    .map(this::validateAllFieldsNotNull)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
             promotions.addAll(pagedPromotions);
@@ -105,7 +106,6 @@ public class CuPromotionBatchService extends PromotionBatchService {
                 .title(title)
                 .thumbnailImage(thumbnailImage)
                 .image(image)
-                .updatedTime(LocalDateTime.now())
                 .storeType(StoreType.CU)
                 .build();
     }

--- a/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PromotionService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PromotionService.java
@@ -1,7 +1,6 @@
 package com.pyonsnalcolor.batch.service.emart24;
 
 import com.pyonsnalcolor.batch.service.PromotionBatchService;
-import com.pyonsnalcolor.product.entity.BasePbProduct;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.promotion.entity.Promotion;
 import com.pyonsnalcolor.promotion.repository.PromotionRepository;
@@ -13,10 +12,12 @@ import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static com.pyonsnalcolor.product.entity.UUIDGenerator.generateId;
 
@@ -32,34 +33,9 @@ public class Emart24PromotionService extends PromotionBatchService {
     }
 
     @Override
-    public List<Promotion> getAllPromotions() {
+    public List<Promotion> getNewPromotions() {
         try {
-            List<Promotion> results = new ArrayList<>();
-
-            Document document = Jsoup.connect(EMART_PROMOTION_URL).get();
-            Elements eventWrap = document.getElementsByClass("eventWrap");
-            for (Element element : eventWrap) {
-                String thumbnailImage = element.getElementsByTag("img").get(0).attr("src");
-                String title = element.getElementsByTag("p").get(0).text().split(" ", 4)[3];
-                String imagePath = element.attr("href");
-                String image = getImageUrl(imagePath);
-
-                Promotion promotion = Promotion.builder()
-                        .id(generateId())
-                        .updatedTime(LocalDateTime.now())
-                        .image(image)
-                        .thumbnailImage(thumbnailImage)
-                        .title(title)
-                        .storeType(StoreType.EMART24)
-                        .build();
-
-                results.add(promotion);
-            }
-
-            for(Promotion p : results) {
-                System.out.println(p);
-            }
-            return results;
+            return getPromotions();
         } catch (Exception e) {
             //TODO : 임시로 모든 예외에 대해 퉁쳐서 처리. 후에 리팩토링 진행할 것
             log.error("fail getAllProducts", e);
@@ -68,13 +44,42 @@ public class Emart24PromotionService extends PromotionBatchService {
         return Collections.emptyList();
     }
 
+    private List<Promotion> getPromotions() throws IOException {
+        List<Promotion> promotions = new ArrayList<>();
+
+        Document document = Jsoup.connect(EMART_PROMOTION_URL).get();
+        Elements elements = document.getElementsByClass("eventWrap");
+
+        List<Promotion> pagedPromotions = elements.stream()
+                .map(this::convertToPromotion)
+                .map(this::validateAllFieldsNotNull)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        promotions.addAll(pagedPromotions);
+        return promotions;
+    }
+
+    private Promotion convertToPromotion(Element element) {
+        String thumbnailImage = element.getElementsByTag("img").get(0).attr("src");
+        String title = element.getElementsByTag("p").get(0).text().split(" ", 4)[3];
+        String imagePath = element.attr("href");
+        String image = getImageUrl(imagePath);
+
+        return Promotion.builder()
+                .id(generateId())
+                .image(image)
+                .thumbnailImage(thumbnailImage)
+                .title(title)
+                .storeType(StoreType.EMART24)
+                .build();
+    }
+
     public String getImageUrl(String imagePath) {
         try {
             String url = EMART_BASE_URL + imagePath;
             Document document = Jsoup.connect(url).get();
             Element element = document.getElementsByClass("contentWrap").get(0);
             String image = element.getElementsByTag("img").get(0).attr("src");
-
             return image;
         } catch (Exception e) {
         }

--- a/src/main/java/com/pyonsnalcolor/product/entity/BaseTimeEntity.java
+++ b/src/main/java/com/pyonsnalcolor/product/entity/BaseTimeEntity.java
@@ -2,7 +2,6 @@ package com.pyonsnalcolor.product.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;

--- a/src/main/java/com/pyonsnalcolor/promotion/dto/PromotionResponseDto.java
+++ b/src/main/java/com/pyonsnalcolor/promotion/dto/PromotionResponseDto.java
@@ -7,10 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
@@ -18,8 +15,9 @@ import java.time.LocalDateTime;
 @Schema(description = "이벤트 상품 조회 Response DTO")
 @ToString(callSuper = true)
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
-@Setter
 public class PromotionResponseDto {
     @NotBlank
     private String id;

--- a/src/main/java/com/pyonsnalcolor/promotion/entity/Promotion.java
+++ b/src/main/java/com/pyonsnalcolor/promotion/entity/Promotion.java
@@ -1,5 +1,6 @@
 package com.pyonsnalcolor.promotion.entity;
 
+import com.pyonsnalcolor.product.entity.BaseTimeEntity;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.promotion.dto.PromotionResponseDto;
 import lombok.Builder;
@@ -9,13 +10,11 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
-
 @Builder
 @ToString
 @Getter
 @Document(collection = "promotion")
-public class Promotion {
+public class Promotion extends BaseTimeEntity {
     @Id
     private String id;
     @Indexed
@@ -23,21 +22,16 @@ public class Promotion {
     private String thumbnailImage;
     private String image;
     private String title;
-    private LocalDateTime updatedTime;
 
     public PromotionResponseDto convertToDto() {
-        PromotionResponseDto promotionResponseDto = new PromotionResponseDto();
-        promotionResponseDto.setId(id);
-        promotionResponseDto.setStoreType(storeType);
-        promotionResponseDto.setThumbnailImage(thumbnailImage);
-        promotionResponseDto.setImage(image);
-        promotionResponseDto.setTitle(title);
-        promotionResponseDto.setUpdatedTime(updatedTime);
 
-        return promotionResponseDto;
-    }
-
-    public void updateImage(String image) {
-        this.image = image;
+        return PromotionResponseDto.builder()
+                .id(id)
+                .image(image)
+                .thumbnailImage(thumbnailImage)
+                .title(title)
+                .storeType(storeType)
+                .updatedTime(getCreatedDate())
+                .build();
     }
 }

--- a/src/main/java/com/pyonsnalcolor/promotion/repository/PromotionRepository.java
+++ b/src/main/java/com/pyonsnalcolor/promotion/repository/PromotionRepository.java
@@ -3,9 +3,11 @@ package com.pyonsnalcolor.promotion.repository;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.promotion.entity.Promotion;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface PromotionRepository extends MongoRepository<Promotion, String> {
     List<Promotion> findByStoreType(StoreType storeType);
 

--- a/src/test/java/com/pyonsnalcolor/batch/service/emart24/Emart24PromotionServiceTest.java
+++ b/src/test/java/com/pyonsnalcolor/batch/service/emart24/Emart24PromotionServiceTest.java
@@ -1,8 +1,6 @@
 package com.pyonsnalcolor.batch.service.emart24;
 
 import com.pyonsnalcolor.batch.service.PromotionBatchService;
-import com.pyonsnalcolor.product.enumtype.StoreType;
-import com.pyonsnalcolor.promotion.repository.PromotionRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -13,13 +11,9 @@ class Emart24PromotionServiceTest {
     @Autowired
     @Qualifier("Emart24Promotion")
     private PromotionBatchService emart24PromotionService;
-    @Autowired
-    private PromotionRepository promotionRepository;
 
     @Test
     public void 통합_테스트() {
-        promotionRepository.deleteByStoreType(StoreType.EMART24);
         emart24PromotionService.execute();
     }
-
 }


### PR DESCRIPTION
### 구현 사항
- **프로모션 배치 로직 수정**
  1 ) 편의점마다 이전 프로모션 모두 삭제 후
  2 ) 현재 진행중인 프로모션만 크롤링하여 저장하도록 수정
  - 프로모션 배치는 PB,행사 상품 배치와 분리하여 매달 1일 크롤링하도록 변경
- **필드 null 검증 로직 추가** 
  - image, thumbnailImage, title 하나라도 null일 경우 크롤링 제외하도록 검증 로직 추가
- 프로모션 페이지 생성/수정 날짜는 공통 엔티티 상속받도록 변경

### 참고 사항
- #76 
- CU 제외하고는 모두 진행중인 프로모션만 조회 가능
- CU는 년도/월로 **이번 달의 프로모션**만 찾아서 크롤링
