### PR TITLE
refactor: 배치 공통 예외 처리 추출

### DIFF
--- a/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PromotionService.java
+++ b/src/main/java/com/pyonsnalcolor/batch/service/emart24/Emart24PromotionService.java
@@ -1,20 +1,18 @@
 package com.pyonsnalcolor.batch.service.emart24;
 
 import com.pyonsnalcolor.batch.service.PromotionBatchService;
+import com.pyonsnalcolor.batch.util.BatchExceptionUtil;
 import com.pyonsnalcolor.product.enumtype.StoreType;
 import com.pyonsnalcolor.promotion.entity.Promotion;
 import com.pyonsnalcolor.promotion.repository.PromotionRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -26,6 +24,7 @@ import static com.pyonsnalcolor.product.entity.UUIDGenerator.generateId;
 public class Emart24PromotionService extends PromotionBatchService {
     private static final String EMART_BASE_URL = "http://www.emart24.co.kr";
     private static final String EMART_PROMOTION_URL = EMART_BASE_URL + "/event/ing";
+    private static final int TIMEOUT = 20000;
 
     @Autowired
     public Emart24PromotionService(PromotionRepository promotionRepository) {
@@ -34,20 +33,13 @@ public class Emart24PromotionService extends PromotionBatchService {
 
     @Override
     public List<Promotion> getNewPromotions() {
-        try {
-            return getPromotions();
-        } catch (Exception e) {
-            //TODO : 임시로 모든 예외에 대해 퉁쳐서 처리. 후에 리팩토링 진행할 것
-            log.error("fail getAllProducts", e);
-        }
-        //TODO : 수정 필요
-        return Collections.emptyList();
+        return BatchExceptionUtil.handleException(this::getPromotions);
     }
 
-    private List<Promotion> getPromotions() throws IOException {
+    private List<Promotion> getPromotions() {
         List<Promotion> promotions = new ArrayList<>();
 
-        Document document = Jsoup.connect(EMART_PROMOTION_URL).get();
+        Document document = BatchExceptionUtil.getDocumentByUrlWithTimeout(EMART_PROMOTION_URL, TIMEOUT);
         Elements elements = document.getElementsByClass("eventWrap");
 
         List<Promotion> pagedPromotions = elements.stream()
@@ -75,14 +67,10 @@ public class Emart24PromotionService extends PromotionBatchService {
     }
 
     public String getImageUrl(String imagePath) {
-        try {
-            String url = EMART_BASE_URL + imagePath;
-            Document document = Jsoup.connect(url).get();
-            Element element = document.getElementsByClass("contentWrap").get(0);
-            String image = element.getElementsByTag("img").get(0).attr("src");
-            return image;
-        } catch (Exception e) {
-        }
-        return null;
+        String url = EMART_BASE_URL + imagePath;
+        Document document = BatchExceptionUtil.getDocumentByUrlWithTimeout(url, TIMEOUT);
+        Element element = document.getElementsByClass("contentWrap").get(0);
+        String image = element.getElementsByTag("img").get(0).attr("src");
+        return image;
     }
 }

--- a/src/main/java/com/pyonsnalcolor/batch/util/BatchExceptionUtil.java
+++ b/src/main/java/com/pyonsnalcolor/batch/util/BatchExceptionUtil.java
@@ -1,0 +1,51 @@
+package com.pyonsnalcolor.batch.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pyonsnalcolor.exception.PyonsnalcolorBatchException;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.pyonsnalcolor.exception.model.BatchErrorCode.*;
+
+public class BatchExceptionUtil {
+
+    public static <T> T handleException(Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (IllegalArgumentException e) {
+            throw new PyonsnalcolorBatchException(INVALID_ACCESS, e);
+        } catch (Exception e) {
+            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
+        }
+    }
+
+    public static Document getDocumentByUrlWithTimeout(String url, int timeOut) {
+        try {
+            return Jsoup.connect(url).timeout(timeOut).get();
+        } catch (IOException e) {
+            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
+        }
+    }
+
+    public static Document getDocumentByConnection(Connection connection, int timeOut) {
+        try {
+            return connection.timeout(timeOut).get();
+        } catch (IOException e) {
+            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
+        }
+    }
+
+    public static Map<String, Object> getPageDataMap(ObjectMapper objectMapper, Object data) {
+        try {
+            return objectMapper.readValue((String) data, Map.class);
+        } catch (JsonProcessingException e) {
+            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
+        }
+    }
+}


### PR DESCRIPTION
### 구현 사항
- **배치 실행 시, 공통 예외 처리 로직(try-catch문) BatchExceptionUtil에 추출**

### 참고 사항
- 기존에 각 BatchService단에서 중간 메소드들이 throws로 모든 예외를 최종 메소드(`getAllProducts()`)로 던져준 방식에서
- 다음처럼 분리해서 처리했습니다.
  - Document 페치 시 예외(IOException)
  - json 파싱 시 예외(JsonProcessingException)
  - 그외의 배치 시 예외들
  - 각각 BatchExceptionUtil에서 공통 try-catch문 추출

**기존**
```java
        try {
            return getProducts();
        } catch (IllegalArgumentException e) {
            throw new PyonsnalcolorBatchException(INVALID_ACCESS, e);
        } catch (SocketTimeoutException e) {
            throw new PyonsnalcolorBatchException(TIME_OUT, e);
        } catch (IOException e) {
            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
        } catch (Exception e) {
            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
        }
```

**예외처리 추출 후**
- BatchExceptionUtil
```java

    public static <T> T handleException(Supplier<T> supplier) {
        try {
            return supplier.get();
        } catch (IllegalArgumentException e) {
            throw new PyonsnalcolorBatchException(INVALID_ACCESS, e);
        } catch (Exception e) {
            throw new PyonsnalcolorBatchException(BATCH_UNAVAILABLE, e);
        }
    }

    public static Document getDocumentByUrlWithTimeout(String url, int timeOut) {
        try {
            return Jsoup.connect(url).timeout(timeOut).get();
        } catch (IOException e) {
            throw new PyonsnalcolorBatchException(IO_EXCEPTION, e);
        }
    }
```

- 배치 서비스단
```java
protected List<BasePbProduct> getAllProducts() {
        return BatchExceptionUtil.handleException(this::getProductsByCategoryAll);
    }
...
    Document document = BatchExceptionUtil.getDocumentByUrlWithTimeout(pagedCuEventUrl, TIMEOUT);


```